### PR TITLE
Lua优化

### DIFF
--- a/Content/Script/UnLua.lua
+++ b/Content/Script/UnLua.lua
@@ -1,6 +1,18 @@
-print = UEPrint
+local rawget = rawget
+local rawset = rawset
+local type = type
+local getmetatable = getmetatable
+local setmetatable = setmetatable
+local require = require
+local str_sub = string.sub
 
-function _G.Index(t, k)
+local GetUProperty = GetUProperty
+local SetUProperty = SetUProperty
+local RegisterClass = RegisterClass
+local RegisterEnum = RegisterEnum
+local print = UEPrint
+
+local function Index(t, k)
 	local mt = getmetatable(t)
 	local super = mt
 	while super do
@@ -20,7 +32,7 @@ function _G.Index(t, k)
 	return p
 end
 
-function _G.NewIndex(t, k, v)
+local function NewIndex(t, k, v)
 	local mt = getmetatable(t)
 	local p = mt[k]
 	if type(p) == "userdata" then
@@ -29,7 +41,7 @@ function _G.NewIndex(t, k, v)
 	rawset(t, k, v)
 end
 
-function _G.Class(super_name)
+local function Class(super_name)
 	local super_class = nil
 	if super_name ~= nil then
 		super_class = require(super_name)
@@ -45,7 +57,7 @@ end
 
 local function global_index(t, k)
 	if type(k) == "string" then
-		local s = string.sub(k, 1, 1)
+		local s = str_sub(k, 1, 1)
 		if s == "U" or s == "A" or s == "F" then
 			RegisterClass(k)
 		elseif s == "E" then
@@ -65,3 +77,8 @@ else
 
 	print("WITH_UE4_NAMESPACE==false");
 end
+
+_G.print = print
+_G.Index = Index
+_G.NewIndex = NewIndex
+_G.Class = Class

--- a/Content/Script/UnLua.lua
+++ b/Content/Script/UnLua.lua
@@ -12,23 +12,36 @@ local RegisterClass = RegisterClass
 local RegisterEnum = RegisterEnum
 local print = UEPrint
 
+_NotExist = _NotExist or {}
+local NotExist = _NotExist
+
 local function Index(t, k)
 	local mt = getmetatable(t)
 	local super = mt
 	while super do
 		local v = rawget(super, k)
-		if v then
+        if v then
+            if rawequal(v, NotExist) then
+                return nil
+            end
 			rawset(t, k, v)
 			return v
 		end
 		super = rawget(super, "Super")
 	end
-	local p = mt[k]
-	if type(p) == "userdata" then
-		return GetUProperty(t, p)
-	elseif type(p) == "function" then
-		rawset(t, k, p)
-	end
+    local p = mt[k]
+
+    if p ~= nil then
+        if type(p) == "userdata" then
+            return GetUProperty(t, p)
+        elseif type(p) == "function" then
+            rawset(t, k, p)
+        elseif rawequal(p, NotExist) then
+            return nil
+        end
+    else
+        rawset(mt, k, NotExist)
+    end
 	return p
 end
 

--- a/Plugins/UnLua/Source/UnLua/Public/UnLuaEx.h
+++ b/Plugins/UnLua/Source/UnLua/Public/UnLuaEx.h
@@ -331,6 +331,8 @@ namespace UnLua
         template <ESPMode Mode, typename... ArgType> void AddSharedPtrConstructor();
         template <ESPMode Mode, typename... ArgType> void AddSharedRefConstructor();
 
+        void AddStaticCFunction(const FString &InName, lua_CFunction InFunc);
+
 #if WITH_EDITOR
         virtual void GenerateIntelliSense(FString &Buffer) const override;
 #endif
@@ -478,6 +480,12 @@ namespace UnLua
 
 #define ADD_EXTERNAL_FUNCTION_EX(Name, RetType, Function, ...) \
             Class->AddStaticFunction<RetType, ##__VA_ARGS__>(Name, Function);
+
+#define ADD_STATIC_CFUNTION(Function) \
+            Class->AddStaticCFunction(#Function, &ClassType::Function);
+
+#define ADD_NAMED_STATIC_CFUNTION(Name, Function) \
+            Class->AddStaticCFunction(Name, &ClassType::Function);
 
 #define ADD_LIB(Lib) \
             Class->AddLib(Lib);

--- a/Plugins/UnLua/Source/UnLua/Public/UnLuaEx.inl
+++ b/Plugins/UnLua/Source/UnLua/Public/UnLuaEx.inl
@@ -925,6 +925,12 @@ namespace UnLua
         FExportedClassBase::Functions.Add(new TSharedRefConstructor<Mode, ClassType, ArgType...>);
     }
 
+    template <bool bIsReflected, typename ClassType, typename... CtorArgType>
+    void TExportedClass<bIsReflected, ClassType, CtorArgType...>::AddStaticCFunction(const FString &InName, lua_CFunction InFunc)
+    {
+        FExportedClassBase::GlueFunctions.Add(new FGlueFunction(InName, InFunc));
+    }
+
 #if WITH_EDITOR
     template <bool bIsReflected, typename ClassType, typename... CtorArgType>
     void TExportedClass<bIsReflected, ClassType, CtorArgType...>::GenerateIntelliSense(FString &Buffer) const


### PR DESCRIPTION
1 增加单个原生函数的导出宏，替代AddLib，原来的AddLib需要luaL_Reg比较难用
2 Unlua.lua的Index性能优化：第一次查询失败时标记，后续查询直接返回nil