### PR TITLE
针对self.Overridden.xxx在关卡重置后调用可能会引起崩溃的问题修复

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Private/LuaFunctionInjection.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/LuaFunctionInjection.cpp
@@ -183,8 +183,16 @@ UFunction* DuplicateUFunction(UFunction *TemplateFunction, UClass *OuterClass, F
  * 3. Remove from root if necessary
  * 4. Clear 'Native' flag if necessary
  */
-void RemoveUFunction(UFunction *Function, UClass *OuterClass)
+void RemoveUFunction(UFunction *Function, UClass *OuterClass, bool ClearCache)
 {
+    if (ClearCache)
+    {
+        FClassDesc* Desc = GReflectionRegistry.RegisterClass(OuterClass);
+        if (Desc)
+        {
+            Desc->UnRegisterField(Function->GetFName());
+        }
+    }
     OuterClass->RemoveFunctionFromFunctionMap(Function);
     GReflectionRegistry.UnRegisterFunction(Function);
     if (GUObjectArray.DisregardForGCEnabled() || GUObjectClusters.GetNumAllocatedClusters())

--- a/Plugins/UnLua/Source/UnLua/Private/LuaFunctionInjection.h
+++ b/Plugins/UnLua/Source/UnLua/Private/LuaFunctionInjection.h
@@ -31,5 +31,5 @@ public:
 
 void GetOverridableFunctions(UClass *Class, TMap<FName, UFunction*> &Functions);
 UFunction* DuplicateUFunction(UFunction *TemplateFunction, UClass *OuterClass, FName NewFuncName);
-void RemoveUFunction(UFunction *Function, UClass *OuterClass);
+void RemoveUFunction(UFunction *Function, UClass *OuterClass, bool ClearCache=false);
 void OverrideUFunction(UFunction *Function, FNativeFuncPtr NativeFunc, void *Userdata, bool bInsertOpcodes = true);

--- a/Plugins/UnLua/Source/UnLua/Private/UEReflectionUtils.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/UEReflectionUtils.cpp
@@ -1490,6 +1490,51 @@ void FClassDesc::Reset()
     ClearLoadedModule(*GLuaCxt, ClassAnsiName.Get());       // clean up required Lua module
 }
 
+void FClassDesc::UnRegisterField(FName FieldName)
+{
+    if (!Struct)
+    {
+        return;
+    }
+    FFieldDesc *FieldDesc = nullptr;
+    FFieldDesc **FieldDescPtr = Fields.Find(FieldName);
+    if (FieldDescPtr)
+    {
+        FieldDesc = *FieldDescPtr;
+    }
+    else {
+        return;
+    }
+    Fields.Remove(FieldName);
+
+    if (FieldDesc->FieldIndex > 0)
+    {
+        delete Properties[FieldDesc->FieldIndex - 1];
+        Properties.RemoveAt(FieldDesc->FieldIndex - 1);
+        for (TMap<FName, FFieldDesc*>::TIterator It(Fields); It; ++It)
+        {
+            FFieldDesc* Desc = It.Value();
+            if (Desc->FieldIndex > FieldDesc->FieldIndex)
+            {
+                --Desc->FieldIndex;
+            }
+        }
+    }
+    else {
+        FFunctionDesc* FuncDesc = Functions[-FieldDesc->FieldIndex - 1];
+        delete FuncDesc;
+        Functions.RemoveAt(-FieldDesc->FieldIndex - 1);
+        for (TMap<FName, FFieldDesc*>::TIterator It(Fields); It; ++It)
+        {
+            FFieldDesc* Desc = It.Value();
+            if (Desc->FieldIndex < FieldDesc->FieldIndex)
+            {
+                ++Desc->FieldIndex;
+            }
+        }
+    }
+    delete FieldDesc;
+}
 /**
  * Register a field of this class
  */

--- a/Plugins/UnLua/Source/UnLua/Private/UEReflectionUtils.h
+++ b/Plugins/UnLua/Source/UnLua/Private/UEReflectionUtils.h
@@ -356,6 +356,7 @@ public:
     {
         return RegisterField(FName(FieldName), this);
     }
+    void UnRegisterField(FName FieldName);
 
     FFieldDesc* RegisterField(FName FieldName, FClassDesc *QueryClass);
 

--- a/Plugins/UnLua/Source/UnLua/Private/UnLuaManager.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/UnLuaManager.cpp
@@ -265,7 +265,7 @@ void UUnLuaManager::CleanupDuplicatedFunctions()
         TArray<UFunction*> &Functions = It.Value();
         for (UFunction *Func : Functions)
         {
-            RemoveUFunction(Func, Class);                           // clean up duplicated UFunction
+            RemoveUFunction(Func, Class, true);                           // clean up duplicated UFunction
 #if ENABLE_CALL_OVERRIDDEN_FUNCTION
             GReflectionRegistry.RemoveOverriddenFunction(Func);
 #endif
@@ -294,7 +294,7 @@ void UUnLuaManager::CleanupCachedNatives()
         UFunction *OverriddenFunc = GReflectionRegistry.RemoveOverriddenFunction(Func);
         if (OverriddenFunc)
         {
-            RemoveUFunction(OverriddenFunc, OverriddenFunc->GetOuterUClass());
+            RemoveUFunction(OverriddenFunc, OverriddenFunc->GetOuterUClass(), true);
         }
 #endif
     }


### PR DESCRIPTION
Overridden调用原理是通过Class_Index中取到GReflectionRegistry缓存的classdesc，然后通过函数名，找到对应的FieldDesc，这个是持久引用的
但是Overridden的函数在关卡重置后会通过CleanupDuplicatedFunctions清掉，即实际UClass上的FuncMap对应的重载函数会被清理掉并重新生成，所以原来引用在ClassDesc里的Fields缓存了脏数据
当这个脏地址被再次写入的时候，这块数据就会变得完全不可用，这时通过Overridden调用的时候会触发崩溃
解决方案，在清理OverriddenFunctiosn的时候，把缓存清掉