### PR TITLE
fix DynamicBinding failed in Loop Call NewObject

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Private/LuaDynamicBinding.h
+++ b/Plugins/UnLua/Source/UnLua/Private/LuaDynamicBinding.h
@@ -24,12 +24,22 @@ struct FLuaDynamicBinding
     {}
 
     bool IsValid(UClass *InClass) const;
-    bool Setup(UClass *InClass, const TCHAR *InModuleName, int32 InInitializerTableRef);
-    int32 Cleanup();
 
     UClass *Class;
     FString ModuleName;
     int32 InitializerTableRef;
+
+    struct FLuaDynamicBindingStackNode
+    {
+        UClass *Class;
+        FString ModuleName;
+        int32 InitializerTableRef;
+    };
+
+    TArray<FLuaDynamicBindingStackNode> Stack;
+
+    bool Push(UClass *InClass, const TCHAR *InModuleName, int32 InInitializerTableRef);
+    int32 Pop();
 };
 
 extern FLuaDynamicBinding GLuaDynamicBinding;


### PR DESCRIPTION
When the call chain of NewObject-> BeginPlay-> NewObject appears, if the second NewObject uses dynamic binding, dynamic binding will fail.

GLuaDynamicBinding is modified to adapt to the call stack, pushing the stack to the call stack for each call.

commit by wittwang