### PR TITLE
修复调用栈上获取对象调用函数会卡死的问题

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Private/DelegateHelper.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/DelegateHelper.cpp
@@ -70,7 +70,7 @@ void FSignatureDesc::Execute(FFrame &Stack, void *RetValueAddress)
     if (SignatureFunctionDesc)
     {
         ++NumCalls;         // inc calls, so it won't be deleted during call
-        SignatureFunctionDesc->CallLua(Stack, RetValueAddress, false, false);
+        SignatureFunctionDesc->CallLua(nullptr, Stack, RetValueAddress, false, false);
         --NumCalls;         // dec calls
         if (!NumCalls && bPendingKill)
         {
@@ -507,8 +507,7 @@ void FDelegateHelper::CreateSignature(UFunction *TemplateFunction, FName FuncNam
     SignatureDesc->CallbackRef = CallbackRef;
     Signatures.Add(SignatureFunction, SignatureDesc);
 
-    // set custom thunk function for the duplicated UFunction
-    OverrideUFunction(SignatureFunction, (FNativeFuncPtr)&FDelegateHelper::ProcessDelegate, SignatureDesc, false);
+	OverrideUFunction(SignatureFunction, (FNativeFuncPtr)&FDelegateHelper::ProcessDelegate, SignatureDesc, false);      // set custom thunk function for the duplicated UFunction
 
     uint8 NumRefProperties = SignatureDesc->SignatureFunctionDesc->GetNumRefProperties();
     if (NumRefProperties > 0)

--- a/Plugins/UnLua/Source/UnLua/Private/LuaFunctionInjection.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/LuaFunctionInjection.cpp
@@ -76,7 +76,10 @@ DEFINE_FUNCTION(FLuaInvoker::execCallLua)
         }
     }
 #endif
-    FuncDesc->CallLua(Stack, (void*)RESULT_PARAM, bRpcCall, bUnpackParams);
+	if (!FuncDesc->CallLua(Context, Stack, (void*)RESULT_PARAM, bRpcCall, bUnpackParams))
+	{
+		Stack.SkipCode(1);
+	}
 }
 
 /**
@@ -164,6 +167,11 @@ UFunction* DuplicateUFunction(UFunction *TemplateFunction, UClass *OuterClass, F
     DuplicationParams.DestName = NewFuncName;
     DuplicationParams.InternalFlagMask &= ~EInternalObjectFlags::Native;
     UFunction *NewFunc = Cast<UFunction>(StaticDuplicateObjectEx(DuplicationParams));
+
+	if (!NewFunc->GetNativeFunc())
+	{
+		NewFunc->SetNativeFunc(TemplateFunction->GetNativeFunc());
+	}
 #else
     UFunction *NewFunc = DuplicateObject(TemplateFunction, OuterClass, NewFuncName);
 #endif
@@ -236,7 +244,7 @@ void RemoveUFunction(UFunction *Function, UClass *OuterClass)
  */
 void OverrideUFunction(UFunction *Function, FNativeFuncPtr NativeFunc, void *Userdata, bool bInsertOpcodes)
 {
-    if (!Function->HasAnyFunctionFlags(FUNC_Net) || Function->HasAnyFunctionFlags(FUNC_Native))
+	if (!Function->HasAnyFunctionFlags(FUNC_Net) || Function->HasAnyFunctionFlags(FUNC_Native))
     {
         Function->SetNativeFunc(NativeFunc);
     }

--- a/Plugins/UnLua/Source/UnLua/Private/UEReflectionUtils.h
+++ b/Plugins/UnLua/Source/UnLua/Private/UEReflectionUtils.h
@@ -266,7 +266,7 @@ public:
      * @param bUnpackParams - whether to unpack parameters from the stack
      * @return - true if the Lua function executes successfully, false otherwise
      */
-    bool CallLua(FFrame &Stack, void *RetValueAddress, bool bRpcCall, bool bUnpackParams);
+    bool CallLua(UObject* Context,FFrame &Stack, void *RetValueAddress, bool bRpcCall, bool bUnpackParams);
 
     /**
      * Call this UFunction

--- a/Plugins/UnLua/Source/UnLua/Private/UnLuaManager.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/UnLuaManager.cpp
@@ -469,15 +469,15 @@ bool UUnLuaManager::ReplaceInputs(AActor *Actor, UInputComponent *InputComponent
 
     UClass *Class = Actor->GetClass();
     FString *ModuleNamePtr = ModuleNames.Find(Class);
-    if (!ModuleNamePtr)
-    {
-        UClass **SuperClassPtr = Derived2BaseClasses.Find(Class);
-        if (!SuperClassPtr || !(*SuperClassPtr))
-        {
-            return false;
-        }
-        ModuleNamePtr = ModuleNames.Find(*SuperClassPtr);
-    }
+	if (!ModuleNamePtr)
+	{
+		UClass **SuperClassPtr = Derived2BaseClasses.Find(Class);
+		if (!SuperClassPtr || !(*SuperClassPtr))
+		{
+			return false;
+		}
+		ModuleNamePtr = ModuleNames.Find(*SuperClassPtr);
+	}
     check(ModuleNamePtr);
     TSet<FName> *LuaFunctionsPtr = ModuleFunctions.Find(*ModuleNamePtr);
     check(LuaFunctionsPtr);


### PR DESCRIPTION
没有现成的示例工程，不过复现方法是这样的：
1. 创建一个C++类 挂上unlua的接口，创建一个UFUNCTION(BlueprintNativeEvent)的函数TESTFUNC，并创建一个_Implementation的实现
2. 创建绑定的lua文件，并在lua文件里覆写TESTFUNC
3. 在游戏的关卡蓝图里创建出来这个C++类，然后在关卡蓝图里调用TESTFUNC函数

调试之后发现的问题是，在关卡蓝图中通过对象调用函数从stack上获取调用Lua函数的对象是关卡蓝图，而不是调用的对象。

还解决了CustomFindProperty函数在UE4.22中是WITH_EDITOR的函数的问题。