### PR TITLE
fix DuplicateUFunction error

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Private/LuaFunctionInjection.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/LuaFunctionInjection.cpp
@@ -179,6 +179,11 @@ UFunction* DuplicateUFunction(UFunction *TemplateFunction, UClass *OuterClass, F
 #else
     UFunction *NewFunc = DuplicateObject(TemplateFunction, OuterClass, NewFuncName);
 #endif
+
+	if (!NewFunc->GetNativeFunc())
+	{
+		NewFunc->SetNativeFunc(TemplateFunction->GetNativeFunc());
+	}
     NewFunc->PropertiesSize = TemplateFunction->PropertiesSize;
     NewFunc->MinAlignment = TemplateFunction->MinAlignment;
     int32 NumParams = NewFunc->NumParms;


### PR DESCRIPTION
看了下上个pr里的这个代码没合并，在DuplicateUFunction的实现里，拷贝函数的部分有问题，copy出来的UFunction的func成员为null，这导致在调用Overridden函数的时候会crash。
![](https://external.imzlp.me/2019/20200419173719.png)
