### PR TITLE
防止uclass被gc时，误清在mark和sweeep之间新建的同名uclass信息

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Private/ReflectionUtils/ReflectionRegistry.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/ReflectionUtils/ReflectionRegistry.cpp
@@ -124,7 +124,11 @@ bool FReflectionRegistry::NotifyUObjectDeleted(const UObjectBase *InObject)
     {
         UE_LOG(LogUnLua, Warning, TEXT("Class/ScriptStruct %s has been GCed by engine!!!"), *ClassDesc->GetName());
         ClassDesc->Reset();
-        Name2Classes.Remove(ClassDesc->GetFName());
+        FClassDesc** PClassDesc = Name2Classes.Find(ClassDesc->GetFName());
+		if (PClassDesc && *PClassDesc == ClassDesc)
+		{
+			Name2Classes.Remove(ClassDesc->GetFName());
+		}
         Struct2Classes.Remove(Struct);
         return true;
     }


### PR DESCRIPTION
你好，实际使用中有以下一种特殊情况
第一步：UE开始GC，执行mark，把uclass作为垃圾，标记为unreachable
第二步：新的同名uclass对象被创建，注册到unlua，对应的Actor被push到lua中
第三步：UE执行分帧清理第一步GC扫描到的垃圾，垃圾uclass删除，Name2Classes被清空。但此时Name2Classes存储的value为新的uclass，并不是垃圾uclass
第四步：lua中新uclass对应Actor执行到GetField，会因为Name2Classes没有Name而check失败

我的想法是只在清Name2Classes时判断，其他ClassMetaTable等照清，顶多之后重新注册一遍，不知合不合适。