### PR TITLE
add iterate function for FLuaTable

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Private/UnLua.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/UnLua.cpp
@@ -140,7 +140,7 @@ namespace UnLua
         return FLuaValue(-1, Type);
     }
 
-    bool FLuaTable::Iterate(std::function<void(const lua_Integer& Index, const FLuaValue& Value)> Func)
+    bool FLuaTable::Iterate(TFunction<void (const lua_Integer& Index, const FLuaValue& Value)> Func) const
     {
         // push table to stack
         lua_pushvalue(*GLuaCxt, Index);
@@ -166,7 +166,7 @@ namespace UnLua
         return true;
     }
 
-    bool FLuaTable::Iterate(const std::function<void (const FName& Key, const FLuaValue& Value)> Func)
+    bool FLuaTable::Iterate(TFunction<void (const FName& Key, const FLuaValue& Value)> Func) const
     {
         // push table to stack
         lua_pushvalue(*GLuaCxt, Index);

--- a/Plugins/UnLua/Source/UnLua/Private/UnLua.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/UnLua.cpp
@@ -140,6 +140,56 @@ namespace UnLua
         return FLuaValue(-1, Type);
     }
 
+    bool FLuaTable::Iterate(std::function<void(const lua_Integer& Index, const FLuaValue& Value)> Func)
+    {
+        // push table to stack
+        lua_pushvalue(*GLuaCxt, Index);
+
+        // get length of array
+        const auto Len = luaL_len(*GLuaCxt, -1);
+
+        // iterate array
+        for (lua_Integer i = 1; i <= Len; i++)
+        {
+            lua_pushinteger(*GLuaCxt, i);
+            lua_gettable(*GLuaCxt, -2);
+
+            Func(i, FLuaValue(-1));
+
+            // pop value from stack
+            lua_pop(*GLuaCxt, 1);
+        }
+
+        // pop table from stack
+        lua_pop(*GLuaCxt, 1);
+
+        return true;
+    }
+
+    bool FLuaTable::Iterate(const std::function<void (const FName& Key, const FLuaValue& Value)> Func)
+    {
+        // push table to stack
+        lua_pushvalue(*GLuaCxt, Index);
+
+        // iterate table
+        lua_pushnil(*GLuaCxt);
+        while (lua_next(*GLuaCxt, -2) != 0)
+        {
+            FName Key(lua_tostring(*GLuaCxt, -2));
+            FLuaValue Value(-1);
+
+            Func(Key, Value);
+
+            // pop value from stack, keep key in stack to continue iterate
+            lua_pop(*GLuaCxt, 1);
+        }
+
+        // pop table from stack
+        lua_pop(*GLuaCxt, 1);
+
+        return true;
+    }
+
     /**
      * Lua function wrapper
      */

--- a/Plugins/UnLua/Source/UnLua/Public/UnLua.h
+++ b/Plugins/UnLua/Source/UnLua/Public/UnLua.h
@@ -117,6 +117,16 @@ namespace UnLua
         template <typename... T>
         FLuaRetValues Call(const char *FuncName, T&&... Args) const;
 
+        /**
+         * Iterate for Array
+         */
+        bool Iterate(std::function<void (const lua_Integer& Index, const FLuaValue& Value)> Func);
+
+        /**
+         * Iterate for Table
+         */
+        bool Iterate(std::function<void (const FName& Key, const FLuaValue& Value)> Func);
+
     private:
         mutable int32 PushedValues;
     };

--- a/Plugins/UnLua/Source/UnLua/Public/UnLua.h
+++ b/Plugins/UnLua/Source/UnLua/Public/UnLua.h
@@ -120,12 +120,12 @@ namespace UnLua
         /**
          * Iterate for Array
          */
-        bool Iterate(std::function<void (const lua_Integer& Index, const FLuaValue& Value)> Func);
+        bool Iterate(TFunction<void (const lua_Integer& Index, const FLuaValue& Value)> Func) const;
 
         /**
          * Iterate for Table
          */
-        bool Iterate(std::function<void (const FName& Key, const FLuaValue& Value)> Func);
+        bool Iterate(TFunction<void (const FName& Key, const FLuaValue& Value)> Func) const;
 
     private:
         mutable int32 PushedValues;


### PR DESCRIPTION
为 FLuaTable 添加 2 个 Iterate 方法
分别用于遍历 Table 和 Array
