### PR TITLE
修改支持不同的蓝图类可以绑定同一个lua类。

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Private/LuaContext.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/LuaContext.cpp
@@ -183,6 +183,10 @@ void FLuaContext::CreateState()
         CreateWeakValueTable(L);
         lua_rawset(L, LUA_REGISTRYINDEX);
 
+        lua_pushstring(L, "MetatableMap");                              // create weak table 'ArrayMap'
+        CreateWeakValueTable(L);
+        lua_rawset(L, LUA_REGISTRYINDEX);
+
         CreateNamespaceForUE(L);                                    // create 'UE4' namespace (table)
 
         // register global Lua functions

--- a/Plugins/UnLua/Source/UnLua/Private/LuaCore.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/LuaCore.cpp
@@ -759,7 +759,8 @@ int32 NewLuaObject(lua_State *L, UObjectBaseUtility *Object, UClass *Class, cons
     lua_pushstring(L, "Object");
     lua_pushvalue(L, -2);
     lua_rawset(L, -4);                                          // INSTANCET.Object = RAW_UOBJECT
-    int32 Type = GetLoadedModule(L, ModuleName);                // push the required module/table ('REQUIRED_MODULE') to the top of the stack
+    int32 Type = GetBindMetatable(L, ModuleName, TCHAR_TO_ANSI(*Object->GetName()));
+    //int32 Type = GetBindMetatable(L, ModuleName);                // push the required module/table ('REQUIRED_MODULE') to the top of the stack
     if (Class)
     {
         TStringConversion<TStringConvert<TCHAR, ANSICHAR>> ClassName(*FString::Printf(TEXT("%s%s"), Class->GetPrefixCPP(), *Class->GetName()));
@@ -1188,6 +1189,55 @@ int32 GetLoadedModule(lua_State *L, const char *ModuleName)
     return Type;
 }
 
+
+/**
+ * Functions to push the metable of (moduleName|ClassName) to the top of stack
+ */
+int32 GetBindMetatable(lua_State *L, const char *ModuleName, const char* ClassName)
+{
+    FString name(ANSI_TO_TCHAR(ModuleName));
+    name.Append(ANSI_TO_TCHAR("||"));
+    name.Append(ANSI_TO_TCHAR(ClassName));
+    lua_getfield(L, LUA_REGISTRYINDEX, "MetatableMap");
+  //  lua_getglobal(L, "MetatableMap");
+    lua_pushstring(L, TCHAR_TO_ANSI(*name));
+    lua_rawget(L, -2);
+    int32 type = lua_type(L, -1);
+    if (type == LUA_TTABLE)
+    {
+        lua_remove(L, -2);
+        return type;
+    }
+    lua_pop(L, 1);
+    lua_newtable(L);                                            //  -2：MetatableMap  -1： newtable，
+ //  lua_rawset(L, -3);
+    type = GetLoadedModule(L, ModuleName); //  ：MetatableMap  ： newtable ： ModuleNametable
+    if (type != LUA_TTABLE)
+    {
+        UE_LOG(LogUnLua, Warning, TEXT("Invalid loaded module object! name:%s"), *ModuleName);
+        return LUA_TNONE;
+    }
+    //copy loaded module to new metatable(ModuleName | ClassName)
+    lua_pushnil(L); 
+    while (lua_next(L, -2) != 0) {
+     //   const char* key = lua_tostring(L, -2);
+    //    UE_LOG(LogUnLua, Warning, TEXT("key is:%s"), key);
+        lua_pushvalue(L, -2);
+        lua_pushvalue(L, -2);
+        ////  ：MetatableMap  ： newtable ： ModuleNametable : key:value:key:value
+        lua_rawset(L, -6);////  ：MetatableMap  ： newtable ： ModuleNametable : key:value:
+        lua_pop(L, 1);
+    }
+    ////  ：MetatableMap  ： newtable ： ModuleNametable 
+    lua_pop(L, 1);
+
+    lua_pushstring(L, TCHAR_TO_ANSI(*name));
+    lua_pushvalue(L, -2);  ////  ：MetatableMap  ： newtable ：string : newtable
+    lua_rawset(L, -4); //
+    lua_remove(L, -2);
+
+    return LUA_TTABLE;
+}
 /**
  * Get collision related enums
  */

--- a/Plugins/UnLua/Source/UnLua/Private/LuaCore.h
+++ b/Plugins/UnLua/Source/UnLua/Private/LuaCore.h
@@ -121,6 +121,11 @@ UNLUA_API void AddPackagePath(lua_State *L, const char *Path);
 void ClearLoadedModule(lua_State *L, const char *ModuleName);
 int32 GetLoadedModule(lua_State *L, const char *ModuleName);
 
+
+/**
+ * Functions to push the metable of (moduleName|ClassName) to the top of stack
+ */
+int32 GetBindMetatable(lua_State *L, const char *ModuleName, const char* ClassName);
 /**
  * Functions to register collision enums
  */


### PR DESCRIPTION
创建新的蓝图对象的时候。 metatable不直接使用 modulename对应的lua的metatable， 而是以 classname 和 modulename拼接为KEY 来找metatable。 比如蓝图类 B1, B2 都绑定了lua L1. 那蓝图B1创建的时候，去全局找一下 "B1_L1" 的metatable。 没有的话就创建一个。    这样只要是B1绑定L1的。都使用 B1_L1 的metatable了。 B2绑定L1的就使用 B2_L1的metatable。 （修复不同的蓝图类绑定同一个lua类 导致 metatable 内容错误）