### PR TITLE
修正枚举推导类型，右值导致类型推导失败bug

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Public/UnLua.inl
+++ b/Plugins/UnLua/Source/UnLua/Public/UnLua.inl
@@ -286,7 +286,7 @@ namespace UnLua
     /**
      * Helper for generic type operation
      */
-    template <typename T, bool IsEnum = TIsEnum<TRemoveReference<T>::Type>::Value>
+    template <typename T, bool IsEnum = TIsEnum<typename TRemoveReference<T>::Type>::Value>
     struct TGenericTypeHelper
     {
         static int32 Push(lua_State *L, T &&V, bool bCopy)

--- a/Plugins/UnLua/Source/UnLua/Public/UnLua.inl
+++ b/Plugins/UnLua/Source/UnLua/Public/UnLua.inl
@@ -286,7 +286,7 @@ namespace UnLua
     /**
      * Helper for generic type operation
      */
-    template <typename T, bool IsEnum = TIsEnum<T>::Value>
+    template <typename T, bool IsEnum = TIsEnum<TRemoveReference<T>::Type>::Value>
     struct TGenericTypeHelper
     {
         static int32 Push(lua_State *L, T &&V, bool bCopy)


### PR DESCRIPTION
遇到三个问题，解决或者绕开
1、右值问题，导致枚举推导失败
2、缓存cache导致基类转子类失败（本次分支没有）
3、luastate销毁后，反射类不再绑定（本次分支没有）
顺便提一下，C++GC类全局变量在lua端需要持有（引用）

提供者：张海军，杨文化