### PR TITLE
Cook时触发Crash后UnLua尝试获取堆栈失败后不打印Error只打印Warning

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Private/LuaContext.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/LuaContext.cpp
@@ -612,9 +612,16 @@ void FLuaContext::OnAsyncLoadingFlushUpdate()
  */
 void FLuaContext::OnCrash()
 {
-    FString LogStr = UnLua::GetLuaCallStack(L);         // get lua call stack...
+    const FString LogStr = UnLua::GetLuaCallStack(L);         // get lua call stack...
 
-    UE_LOG(LogUnLua, Error, TEXT("%s"), *LogStr);
+    if (!LogStr.IsEmpty())
+    {
+        UE_LOG(LogUnLua, Error, TEXT("%s"), *LogStr);
+    }
+    else
+    {
+        UE_LOG(LogUnLua, Warning, TEXT("Lua state is not created."));
+    }
 
     GLog->Flush();
 }

--- a/Plugins/UnLua/Source/UnLua/Private/UnLuaDebugBase.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/UnLuaDebugBase.cpp
@@ -664,7 +664,7 @@ namespace UnLua
     {
         if (!L)
         {
-            return TEXT("Lua state is not created!!!");
+            return FString();
         }
 
         int32 Depth = 0;


### PR DESCRIPTION
Cook时触发Crash后UnLua尝试获取堆栈失败后打印会Error，修改为不打印Error只打印Warning。LuaState没有创建，报错和Lua无关。同时将三个感叹号改为一个句点，既然不是Error，就不用这么强的语气 :)