### PR TITLE
部分情况下为TArray创建拷贝至lua时会产生崩溃

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Private/UnLuaBase.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/UnLuaBase.cpp
@@ -462,6 +462,7 @@ namespace UnLua
                 uint8 *DestData = (uint8*)DestScriptArray->GetData();
                 for (int32 i = 0; i < Num; ++i)
                 {
+                    TypeInterface->Initialize(DestData);
                     TypeInterface->Copy(DestData, SrcData);     // copy data
                     SrcData += ElementSize;
                     DestData += ElementSize;


### PR DESCRIPTION
拷贝TArray\<FString\>对象至lua即可复现。