### PR TITLE
Fix lua class Index

### DIFF
--- a/Content/Script/UnLua.lua
+++ b/Content/Script/UnLua.lua
@@ -20,28 +20,26 @@ local function Index(t, k)
 	local super = mt
 	while super do
 		local v = rawget(super, k)
-        if v~= nil then
-            if rawequal(v, NotExist) then
-                return nil
-            end
+		if v ~= nil and not rawequal(v, NotExist) then
 			rawset(t, k, v)
 			return v
 		end
 		super = rawget(super, "Super")
 	end
-    local p = mt[k]
 
-    if p ~= nil then
-        if type(p) == "userdata" then
-            return GetUProperty(t, p)
-        elseif type(p) == "function" then
-            rawset(t, k, p)
-        elseif rawequal(p, NotExist) then
-            return nil
-        end
-    else
-        rawset(mt, k, NotExist)
-    end
+	local p = mt[k]
+	if p ~= nil then
+		if type(p) == "userdata" then
+			return GetUProperty(t, p)
+		elseif type(p) == "function" then
+			rawset(t, k, p)
+		elseif rawequal(p, NotExist) then
+			return nil
+		end
+	else
+		rawset(mt, k, NotExist)
+	end
+
 	return p
 end
 
@@ -65,7 +63,7 @@ local function Class(super_name)
 	new_class.__newindex = NewIndex
 	new_class.Super = super_class
 
-    return new_class
+  return new_class
 end
 
 local function global_index(t, k)

--- a/Plugins/UnLua/Content/UnLua.lua
+++ b/Plugins/UnLua/Content/UnLua.lua
@@ -20,28 +20,26 @@ local function Index(t, k)
 	local super = mt
 	while super do
 		local v = rawget(super, k)
-        if v~= nil then
-            if rawequal(v, NotExist) then
-                return nil
-            end
+		if v ~= nil and not rawequal(v, NotExist) then
 			rawset(t, k, v)
 			return v
 		end
 		super = rawget(super, "Super")
 	end
-    local p = mt[k]
 
-    if p ~= nil then
-        if type(p) == "userdata" then
-            return GetUProperty(t, p)
-        elseif type(p) == "function" then
-            rawset(t, k, p)
-        elseif rawequal(p, NotExist) then
-            return nil
-        end
-    else
-        rawset(mt, k, NotExist)
-    end
+	local p = mt[k]
+	if p ~= nil then
+		if type(p) == "userdata" then
+			return GetUProperty(t, p)
+		elseif type(p) == "function" then
+			rawset(t, k, p)
+		elseif rawequal(p, NotExist) then
+			return nil
+		end
+	else
+		rawset(mt, k, NotExist)
+	end
+
 	return p
 end
 
@@ -65,7 +63,7 @@ local function Class(super_name)
 	new_class.__newindex = NewIndex
 	new_class.Super = super_class
 
-    return new_class
+  return new_class
 end
 
 local function global_index(t, k)
@@ -87,6 +85,7 @@ else
 	global_mt.__index = global_index
 	setmetatable(_G, global_mt)
 	UE4 = _G
+    UE = _G
 
 	print("WITH_UE4_NAMESPACE==false");
 end


### PR DESCRIPTION
bug: 如果 super 中不存在的值为设置为 NoExist ，而 child 有这个值的话，child 也只能取到 nil 值。
修改： 在 super 检查中，忽略 NotExist.

测试例子：

创建一个蓝图类 BP_Ａ，然后又增加了一个 BP_A 的子类蓝图 BP_A_Child， 并在 BP_A_Child 中加入了一个 Cube  Component

然后在 Lua 中，BP_A 有 BP_A_C, BP_A_Child_C 继承 lua class BP_A_C。

任何时候， 如果 BP_A_C 中尝试去检查 `self.Cube` 就会将 mt 设置为 NoExist。 之后 BP_A_Child_C 虽然有 self.Cube, 但因为 Super 已经把 Cube 设置为 NoExist, 他将永远取不到 self.Cube 了。