### PR TITLE
Support spawn actor with level & name

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Private/BaseLib/LuaLib_World.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/BaseLib/LuaLib_World.cpp
@@ -19,8 +19,12 @@
 
 /**
  * Spawn an actor.
- * for example: World:SpawnActor(WeaponClass, InitialTransform, ESpawnActorCollisionHandlingMethod.AlwaysSpawn, Player, Player, "Weapon.AK47_C", WeaponColor),
- * the last two parameters "Weapon.AK47_C" and 'WeaponColor' and optional.
+ * for example:
+ * World:SpawnActor(
+ *  WeaponClass, InitialTransform, ESpawnActorCollisionHandlingMethod.AlwaysSpawn,
+ *  OwnerActor, Instigator, "Weapon.AK47_C", WeaponColor, ULevel, Name
+ * )
+ * the last four parameters "Weapon.AK47_C", 'WeaponColor', ULevel and Name are optional.
  * see programming guide for detail.
  */
 static int32 UWorld_SpawnActor(lua_State *L)

--- a/Plugins/UnLua/Source/UnLua/Private/BaseLib/LuaLib_World.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/BaseLib/LuaLib_World.cpp
@@ -1,15 +1,15 @@
 // Tencent is pleased to support the open source community by making UnLua available.
-// 
+//
 // Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
 //
-// Licensed under the MIT License (the "License"); 
+// Licensed under the MIT License (the "License");
 // you may not use this file except in compliance with the License. You may obtain a copy of the License at
 //
 // http://opensource.org/licenses/MIT
 //
-// Unless required by applicable law or agreed to in writing, 
-// software distributed under the License is distributed on an "AS IS" BASIS, 
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and limitations under the License.
 
 #include "UnLuaEx.h"
@@ -18,8 +18,8 @@
 #include "Engine/World.h"
 
 /**
- * Spawn an actor. 
- * for example: World:SpawnActor(WeaponClass, InitialTransform, ESpawnActorCollisionHandlingMethod.AlwaysSpawn, Player, Player, "Weapon.AK47_C", WeaponColor), 
+ * Spawn an actor.
+ * for example: World:SpawnActor(WeaponClass, InitialTransform, ESpawnActorCollisionHandlingMethod.AlwaysSpawn, Player, Player, "Weapon.AK47_C", WeaponColor),
  * the last two parameters "Weapon.AK47_C" and 'WeaponColor' and optional.
  * see programming guide for detail.
  */
@@ -83,6 +83,17 @@ static int32 UWorld_SpawnActor(lua_State *L)
             }
             SpawnParameters.Instigator = Instigator;
         }
+    }
+
+    if (NumParams > 8) {
+        ULevel *Level = Cast<ULevel>(UnLua::GetUObject(L, 9));
+        if (Level) {
+            SpawnParameters.OverrideLevel = Level;
+        }
+    }
+
+    if (NumParams > 9) {
+        SpawnParameters.Name = FName(lua_tostring(L, 10));
     }
 
     {


### PR DESCRIPTION
l加了两个参数
level 用于 unload steaming level 时，能自动删除动态创建的 actor
name 用于存档恢复时，actor 可以保持相同的名字。