### PR TITLE
更好的支持 Lua class 的继承

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ IOS/
 *.xcworkspace
 /.idea
 /TPSProject.sln.DotSettings.user
+/.vscode

--- a/Content/Script/AI/BP_AICharacter_C.lua
+++ b/Content/Script/AI/BP_AICharacter_C.lua
@@ -3,7 +3,7 @@ require "UnLua"
 local BP_AICharacter_C= Class("BP_CharacterBase_C")
 
 function BP_AICharacter_C:Initialize(Initializer)
-	self.Super.Initialize(self)
+	BP_AICharacter_C.Super.Initialize(self)
 	self.Damage = 128.0
 	--self.DamageType = UE.UClass.Load("/Script/Engine.DamageType")
 	self.DamageType = UE.UClass.Load("UDamageType")
@@ -13,12 +13,12 @@ end
 --end
 
 function BP_AICharacter_C:ReceiveBeginPlay()
-	self.Super.ReceiveBeginPlay(self)
+	BP_AICharacter_C.Super.ReceiveBeginPlay(self)
 	self.Sphere.OnComponentBeginOverlap:Add(self, BP_AICharacter_C.OnComponentBeginOverlap_Sphere)
 end
 
 function BP_AICharacter_C:Died(DamageType)
-	self.Super.Died(self, DamageType)
+	BP_AICharacter_C.Super.Died(self, DamageType)
 	self.Sphere:SetCollisionEnabled(UE.ECollisionEnabled.NoCollision)
 	local NewLocation = UE.FVector(0.0, 0.0, self.CapsuleComponent.CapsuleHalfHeight)
 	local SweepHitResult = UE.FHitResult()

--- a/Content/Script/Player/BP_PlayerCharacter_C.lua
+++ b/Content/Script/Player/BP_PlayerCharacter_C.lua
@@ -30,7 +30,7 @@ function BP_PlayerCharacter_C:SpawnWeapon()
 end
 
 function BP_PlayerCharacter_C:ReceiveBeginPlay()
-	self.Super.ReceiveBeginPlay(self)
+	BP_PlayerCharacter_C.Super.ReceiveBeginPlay(self)
 	self.DefaultFOV = self.Camera.FieldOfView
 	self.TimerHandle = UE.UKismetSystemLibrary.K2_SetTimerDelegate({self, BP_PlayerCharacter_C.FallCheck}, 1.0, true)
 	local InterpFloats = self.ZoomInOut.TheTimeline.InterpFloats

--- a/Content/Script/UnLua.lua
+++ b/Content/Script/UnLua.lua
@@ -56,7 +56,7 @@ local function Class(super_name)
 	local new_class = nil
 	if super_name ~= nil then
 		local super_class = require(super_name)
-	 	new_class = setmetatable({}, super_class)
+	 	new_class = setmetatable({}, { __index = super_class })
 		new_class.Super = super_class
 	else
 		new_class = {}

--- a/Content/Script/UnLua.lua
+++ b/Content/Script/UnLua.lua
@@ -53,15 +53,17 @@ local function NewIndex(t, k, v)
 end
 
 local function Class(super_name)
-	local super_class = nil
+	local new_class = nil
 	if super_name ~= nil then
-		super_class = require(super_name)
+		local super_class = require(super_name)
+	 	new_class = setmetatable({}, super_class)
+		new_class.Super = super_class
+	else
+		new_class = {}
 	end
 
-	local new_class = {}
 	new_class.__index = Index
 	new_class.__newindex = NewIndex
-	new_class.Super = super_class
 
   return new_class
 end

--- a/Content/Script/Weapon/BP_DefaultProjectile_C.lua
+++ b/Content/Script/Weapon/BP_DefaultProjectile_C.lua
@@ -9,12 +9,12 @@ function BP_DefaultProjectile_C:Initialize(Initializer)
 end
 
 function BP_DefaultProjectile_C:UserConstructionScript()
-	self.Super.UserConstructionScript(self)
+	BP_DefaultProjectile_C.Super.UserConstructionScript(self)
 	self.DamageType = UE.UClass.Load("/Game/Core/Blueprints/BP_DamageType.BP_DamageType_C")
 end
 
 function BP_DefaultProjectile_C:ReceiveBeginPlay()
-	self.Super.ReceiveBeginPlay(self)
+	BP_DefaultProjectile_C.Super.ReceiveBeginPlay(self)
 	local MID = self.StaticMesh:CreateDynamicMaterialInstance(0)
 	if MID then
 		MID:SetVectorParameterValue("BaseColor", self.BaseColor)

--- a/Content/Script/Weapon/BP_DefaultWeapon_C.lua
+++ b/Content/Script/Weapon/BP_DefaultWeapon_C.lua
@@ -3,7 +3,7 @@ require "UnLua"
 local BP_DefaultWeapon_C = Class("Weapon.BP_WeaponBase_C")
 
 function BP_DefaultWeapon_C:UserConstructionScript()
-	self.Super.UserConstructionScript(self)
+	BP_DefaultWeapon_C.Super.UserConstructionScript(self)
 	self.InfiniteAmmo = true
 	self.ProjectileClass = UE.UClass.Load("/Game/Core/Blueprints/Weapon/BP_DefaultProjectile")
 	self.MuzzleSocketName = "Muzzle"

--- a/Plugins/UnLua/Content/UnLua.lua
+++ b/Plugins/UnLua/Content/UnLua.lua
@@ -53,15 +53,17 @@ local function NewIndex(t, k, v)
 end
 
 local function Class(super_name)
-	local super_class = nil
+	local new_class = nil
 	if super_name ~= nil then
-		super_class = require(super_name)
+		local super_class = require(super_name)
+	 	new_class = setmetatable({}, super_class)
+		new_class.Super = super_class
+	else
+		new_class = {}
 	end
 
-	local new_class = {}
 	new_class.__index = Index
 	new_class.__newindex = NewIndex
-	new_class.Super = super_class
 
   return new_class
 end

--- a/Plugins/UnLua/Content/UnLua.lua
+++ b/Plugins/UnLua/Content/UnLua.lua
@@ -56,7 +56,7 @@ local function Class(super_name)
 	local new_class = nil
 	if super_name ~= nil then
 		local super_class = require(super_name)
-	 	new_class = setmetatable({}, super_class)
+		new_class = setmetatable({}, { __index = super_class })
 		new_class.Super = super_class
 	else
 		new_class = {}


### PR DESCRIPTION
```lua
local A = Class()

function A:Initialize()
end

local B = Class('path to a')

local C = Class('path to b')

function C:initialize()
  C.Super.Initialize(self)
end
```

修改前， C.Super.initialize 是没有的，因为 C 继承的 B 没有 Initialize， 并且也不会向上去查找
修改后， 每个 class 都会向上查找 Initialize

#318 同样也是这个问题

之前的 self.Super 的写法对于多层的继承就会有问题，新的方式可以基于 Class.Super 正常执行。


新的 class 继承方式为

```lua
new_class = setmetatable({}, { __index = super_class })
```

和 Index 完全分开了。

本来写的  `new_class = setmetatable({}, super_class)` ，但这样会和 Property Index 混在一起。就创建了一个新表来当 metatable 了。
