### PR TITLE
Crash修复：Delegate Cleanup时，如果Delegate对象已经被析构了，会引发crash。没有开启AsyncLoadingThread时，异步加载对象时发生crash。

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Private/DelegateHelper.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/DelegateHelper.cpp
@@ -503,13 +503,19 @@ void FDelegateHelper::Cleanup(bool bFullCleanup)
 
     for (TMap<FScriptDelegate*, FFunctionDesc*>::TIterator It(Delegate2Signatures); It; ++It)
     {
-        GReflectionRegistry.UnRegisterFunction(It.Value()->GetFunction());
+        if (It.Value()->IsValid())
+        {
+            GReflectionRegistry.UnRegisterFunction(It.Value()->GetFunction());
+        }
     }
     Delegate2Signatures.Empty();
 
     for (TMap<FMulticastDelegateType*, FFunctionDesc*>::TIterator It(MulticastDelegate2Signatures); It; ++It)
     {
-        GReflectionRegistry.UnRegisterFunction(It.Value()->GetFunction());
+        if (It.Value()->IsValid())
+        {
+            GReflectionRegistry.UnRegisterFunction(It.Value()->GetFunction());
+        }
     }
     MulticastDelegate2Signatures.Empty();
 

--- a/Plugins/UnLua/Source/UnLua/Private/LuaContext.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/LuaContext.cpp
@@ -353,7 +353,7 @@ bool FLuaContext::TryToBindLua(UObject* Object)
         return false;
     }
 
-    if (!IsInGameThread() || Object->HasAnyInternalFlags(AsyncObjectFlags))
+    if (IsInAsyncLoadingThread())
     {
         // all bind operation should be in game thread, include dynamic bind
         FScopeLock Lock(&Async2MainCS);


### PR DESCRIPTION
现象：Delegate Cleanup时，如果Delegate对象已经被析构了，会引发crash。在-game运行下特别容易触发。
修改方法：UnRegister前对Delegate对象进行IsValid判定。