### PR TITLE
unlua candidates need check UnLuaInterface Implement,avoid adding too…

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Private/LuaEnv.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/LuaEnv.cpp
@@ -245,17 +245,22 @@ namespace UnLua
             return false;
         }
 
+        static UClass* InterfaceClass = UUnLuaInterface::StaticClass();
+        const bool bImplUnluaInterface = Class->ImplementsInterface(InterfaceClass);
+        
         if (!IsInGameThread() || Object->HasAnyInternalFlags(AsyncObjectFlags))
         {
-            // all bind operation should be in game thread, include dynamic bind
-            FScopeLock Lock(&CandidatesLock);
-            Candidates.AddUnique(Object);
-            return false;
+            // avoid adding too many objects, affecting performance.
+            if (bImplUnluaInterface || (!bImplUnluaInterface && GLuaDynamicBinding.IsValid(Class)))
+            {
+                // all bind operation should be in game thread, include dynamic bind
+                FScopeLock Lock(&CandidatesLock);
+                Candidates.AddUnique(Object);
+                return false;
+            }
         }
 
-        static UClass* InterfaceClass = UUnLuaInterface::StaticClass();
-
-        if (!Class->ImplementsInterface(InterfaceClass))
+        if (!bImplUnluaInterface)
         {
             // dynamic binding
             if (!GLuaDynamicBinding.IsValid(Class))


### PR DESCRIPTION
如果不先检查UnLuaInterface接口，会添加大量UObject的，几W个UObject在遍历binding时产生巨大的性能问题。