### PR TITLE
修复蓝图枚举释放后无法导出成员到lua的BUG

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Private/Registries/EnumRegistry.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/Registries/EnumRegistry.cpp
@@ -43,7 +43,7 @@ namespace UnLua
     FEnumDesc* FEnumRegistry::StaticRegister(const char* MetatableName)
     {
         FEnumDesc* Ret = Find(MetatableName);
-        if (Ret)
+        if (Ret && Ret->IsValid())
             return Ret;
 
         const FString EnumName = UTF8_TO_TCHAR(MetatableName);
@@ -53,7 +53,14 @@ namespace UnLua
             Enum = LoadObject<UEnum>(nullptr, *EnumName);
             if (!Enum)
                 return nullptr;
-        }
+		}
+
+		if (Ret && !Ret->IsValid())
+		{
+            Name2Enums.Remove(MetatableName);
+
+            delete Ret;
+		}
 
         Ret = new FEnumDesc(Enum);
         Enums.Add(Enum, Ret);


### PR DESCRIPTION
![77BHA)R0T6_JB3(WIT{DCCA](https://user-images.githubusercontent.com/12391857/184825818-e6cf45de-9469-441f-8647-5715b407b24b.png)