### PR TITLE
修正：lua注册的函数回调，函数有不释放的情况

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Private/Registries/DelegateRegistry.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/Registries/DelegateRegistry.cpp
@@ -71,8 +71,7 @@ namespace UnLua
         for (auto& Key : ToRemove)
         {
             TWeakObjectPtr<ULuaDelegateHandler> Handler;
-            if (CachedHandlers.RemoveAndCopyValue(Key, Handler) && Handler.IsValid())
-                Handler->Reset();
+            CachedHandlers.RemoveAndCopyValue(Key, Handler);
         }
     }
 


### PR DESCRIPTION
去掉这里的Reset，否则Handler在Destroy时，没法unref