### PR TITLE
修改：UObject_IsValid CallUE增加Unreachable判断和提示 避免Invoke check崩溃

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Private/BaseLib/LuaLib_Object.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/BaseLib/LuaLib_Object.cpp
@@ -78,7 +78,7 @@ static int32 UObject_IsValid(lua_State* L)
         return luaL_error(L, "invalid parameters");
 
     UObject* Object = UnLua::GetUObject(L, 1);
-    const bool bValid = UnLua::IsUObjectValid(Object) && IsValid(Object);
+    const bool bValid = UnLua::IsUObjectValid(Object) && IsValid(Object) && !Object->IsUnreachable();
     lua_pushboolean(L, bValid);
     return 1;
 }

--- a/Plugins/UnLua/Source/UnLua/Private/ReflectionUtils/FunctionDesc.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/ReflectionUtils/FunctionDesc.cpp
@@ -276,6 +276,9 @@ int32 FFunctionDesc::CallUE(lua_State *L, int32 NumParams, void *Userdata)
     if (Object == nullptr)
         return luaL_error(L, "attempt to call UFunction '%s' on NULL object. (check the usage of ':' and '.')", TCHAR_TO_UTF8(*FuncName));
 
+    if (Object->IsUnreachable())
+        return luaL_error(L, "attempt to call UFunction '%s' on Unreachable object '%s'.", TCHAR_TO_UTF8(*FuncName), TCHAR_TO_UTF8(*Object->GetName()));
+
 #if SUPPORTS_RPC_CALL
     int32 Callspace = Object->GetFunctionCallspace(Function.Get(), nullptr);
     bool bRemote = Callspace & FunctionCallspace::Remote;


### PR DESCRIPTION
UObject::ProcessEvent是禁止Unreachable的UObject调用的，会导致check崩溃，所以Lua侧的IsValid判断增加Unreachable检查比较合理。