### PR TITLE
FIX:  NullPointer error in function 'CheckPropertyType'

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Private/ReflectionUtils/PropertyDesc.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/ReflectionUtils/PropertyDesc.cpp
@@ -1282,7 +1282,7 @@ public:
             UScriptStruct* ScriptStruct = CurrentClassDesc->AsScriptStruct();
             if (!ScriptStruct || !ScriptStruct->IsChildOf(StructProperty->Struct))
             {
-                ErrorMsg = FString::Printf(TEXT("struct %s needed but got %s"), *StructProperty->Struct->GetName(), *ScriptStruct->GetName());
+                ErrorMsg = FString::Printf(TEXT("struct %s needed but got %s"), *StructProperty->Struct->GetName(), ScriptStruct? *ScriptStruct->GetName(): TEXT("nil"));
                 return false;
             }
         }


### PR DESCRIPTION
修复 PropertyDesc.cpp 中 CheckPropertyType 函数 ScriptStruct变量引起的空指针异常。