### PR TITLE
Lua侧 NewObject-Outter 传 nil 时使用 TransientPackage

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Private/UELib.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/UELib.cpp
@@ -97,7 +97,7 @@ static int32 Global_NewObject(lua_State *L)
         return 0;
     }
 
-    UObject *Outer = NumParams > 1 ? UnLua::GetUObject(L, 2) : (UObject*)GetTransientPackage();
+    UObject* Outer = (NumParams > 1 && lua_isnil(L, 2)) ? (UObject*)GetTransientPackage() : UnLua::GetUObject(L, 2);
     if (!Outer)
     {
         UNLUA_LOGERROR(L, LogUnLua, Log, TEXT("%s: Invalid outer!"), ANSI_TO_TCHAR(__FUNCTION__));


### PR DESCRIPTION
Before

```Lua
local tempUObject = NewObject(UClass, nil ,FName,luaBindPath) 
-- Output:  Invalid outer!
```

After

```Lua
local tempUObject = NewObject(UClass, nil ,FName,luaBindPath) 
-- Output:  UObject* (Outter = TransientPackage)
```