### PR TITLE
fix:UE.TArray(0) 使用 int32表示值，添加大于 int32.maxvalue 造成溢出

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Private/Registries/PropertyRegistry.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/Registries/PropertyRegistry.cpp
@@ -32,7 +32,7 @@ namespace UnLua
             TypeInterface = GetBoolProperty();
             break;
         case LUA_TNUMBER:
-            TypeInterface = lua_isinteger(L, Index) > 0 ? GetIntProperty() : GetFloatProperty();
+            TypeInterface = lua_isinteger(L, Index) > 0 ? GetInt64Property() : GetFloatProperty();
             break;
         case LUA_TSTRING:
             TypeInterface = GetStringProperty();
@@ -143,6 +143,33 @@ namespace UnLua
             IntProperty = TSharedPtr<ITypeInterface>(FPropertyDesc::Create(Property));
         }
         return IntProperty;
+    }
+    
+    TSharedPtr<ITypeInterface> FPropertyRegistry::GetInt64Property()
+    {
+        if (!Int64Property)
+        {
+#if UE_VERSION_OLDER_THAN(5, 1, 0)
+            const auto Property = new FInt64Property(PropertyCollector, NAME_None, RF_Transient, 0, CPF_HasGetValueTypeHash);
+#else
+            constexpr auto Params = UECodeGen_Private::FInt64PropertyParams
+            {
+                nullptr,
+                nullptr,
+                CPF_HasGetValueTypeHash,
+                UECodeGen_Private::EPropertyGenFlags::Int64,
+                RF_Transient,
+                1,
+                nullptr,
+                nullptr,
+                0,
+                METADATA_PARAMS(nullptr, 0)
+            };
+            const auto Property = new FInt64Property(PropertyCollector, Params);
+#endif
+            Int64Property = TSharedPtr<ITypeInterface>(FPropertyDesc::Create(Property));
+        }
+        return Int64Property;
     }
 
     TSharedPtr<ITypeInterface> FPropertyRegistry::GetFloatProperty()

--- a/Plugins/UnLua/Source/UnLua/Private/Registries/PropertyRegistry.h
+++ b/Plugins/UnLua/Source/UnLua/Private/Registries/PropertyRegistry.h
@@ -42,6 +42,7 @@ namespace UnLua
     private:
         TSharedPtr<ITypeInterface> GetBoolProperty();
         TSharedPtr<ITypeInterface> GetIntProperty();
+        TSharedPtr<ITypeInterface> GetInt64Property();
         TSharedPtr<ITypeInterface> GetFloatProperty();
         TSharedPtr<ITypeInterface> GetStringProperty();
         TSharedPtr<ITypeInterface> GetNameProperty();
@@ -53,6 +54,7 @@ namespace UnLua
         TMap<UField*, TSharedPtr<ITypeInterface>> FieldProperties;
         TSharedPtr<ITypeInterface> BoolProperty;
         TSharedPtr<ITypeInterface> IntProperty;
+        TSharedPtr<ITypeInterface> Int64Property;
         TSharedPtr<ITypeInterface> FloatProperty;
         TSharedPtr<ITypeInterface> StringProperty;
         TSharedPtr<ITypeInterface> NameProperty;


### PR DESCRIPTION
Lua中使用 long long 类型表示 integer，这里是否调整为GetInt64Property 更能匹配lua中的类型定义？
```
local array = UE.TArray(0)
array:Add(1024)
array:Add(math.maxinteger)
array:Add(math.mininteger)
UE.UTutorialBlueprintFunctionLibrary.CallLuaByGlobalTable(array)
```
在c++中的CallLuaByGlobalTable 获取到 array的值将分别为 1024 4294967295 0造成溢出的情况。