### PR TITLE
修改：FObjectRegistry::Push增加Valid检查 规避一些容器内野指针的情况

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Private/Registries/ObjectRegistry.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/Registries/ObjectRegistry.cpp
@@ -88,6 +88,13 @@ namespace UnLua
             return;
         }
 
+        // avoid invalid ptrs in containers from lua
+        if (!UnLua::IsUObjectValid(Object))
+        {
+            luaL_error(L, "attempt to read invalid uobject ptr from lua, maybe from containers like TArray.");
+            return;
+        }
+
         lua_getfield(L, LUA_REGISTRYINDEX, REGISTRY_KEY);
         lua_pushlightuserdata(L, Object);
         const auto Type = lua_rawget(L, -2);


### PR DESCRIPTION
从TArray_Get读取容器内UObject指针时没有地方进行IsUObjectValid检查，如果容器内存在野指针，崩溃时无法知道是哪里的lua调用的，很难查。在Push增加检查可以规避一些野指针的情况，并且显示出lua堆栈。