### PR TITLE
修正：访问来自非native父类的property时检查有效性 #661

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Private/LuaCore.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/LuaCore.cpp
@@ -1001,6 +1001,23 @@ static void GetFieldInternal(lua_State* L)
             lua_pushvalue(L, 2);
             Type = lua_rawget(L, -2);
             bCached = Type != LUA_TNIL;
+            // check cached property from non-native class
+            if (bCached && !Field->OuterClass->IsNative())
+            {
+                auto Ptr = lua_touserdata(L, -1);
+                if (Ptr)
+                {
+                    auto Property = static_cast<TSharedPtr<UnLua::ITypeOps>*>(Ptr);
+                    if (Property && Property->IsValid())
+                    {
+                        auto PropertyDesc = static_cast<FPropertyDesc*>((*Property).Get());
+                        if (!PropertyDesc->IsValid())
+                        {
+                            bCached = false;
+                        }
+                    }
+                }
+            }
             if (!bCached)
             {
                 lua_pop(L, 1);


### PR DESCRIPTION
访问非native的父类缓存的property时检查property有效性，无效则重新pushfield