### PR TITLE
解决lua调用c++自定义导出函数传递nil参数奔溃问题

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Public/UnLuaEx.inl
+++ b/Plugins/UnLua/Source/UnLua/Public/UnLuaEx.inl
@@ -250,6 +250,14 @@ namespace UnLua
         return TTuple<T...>(UnLua::Get(L, Offset + N, TType<T>())...);
     }
 
+    /**
+	 * Get arguments from Lua stack, avoid nullptr access crash but throw lua error
+	 */
+	template <typename... T, uint32... N>
+	FORCEINLINE_DEBUGGABLE TTuple<T...> GetArgsChecked(lua_State *L, TIndices<N...>, uint32 Offset = 0)
+    {
+    	return TTuple<T...>(UnLua::GetChecked(L, Offset + N, TType<T>())...);
+    }
 
     /**
      * Generic closure to help invoke exported function
@@ -367,7 +375,7 @@ namespace UnLua
             return 0;
         }
 
-        TTuple<typename TArgTypeTraits<ArgType>::Type...> Args = GetArgs<typename TArgTypeTraits<ArgType>::Type...>(L, typename TOneBasedIndices<Expected>::Type(), 1);
+        TTuple<typename TArgTypeTraits<ArgType>::Type...> Args = GetArgsChecked<typename TArgTypeTraits<ArgType>::Type...>(L, typename TOneBasedIndices<Expected>::Type(), 1);
         Construct(L, Args, typename TZeroBasedIndices<Expected>::Type());
         return 1;
     }
@@ -444,7 +452,7 @@ namespace UnLua
             return 0;
         }
 
-        TTuple<typename TArgTypeTraits<ArgType>::Type...> Args = GetArgs<typename TArgTypeTraits<ArgType>::Type...>(L, typename TOneBasedIndices<Expected>::Type());
+        TTuple<typename TArgTypeTraits<ArgType>::Type...> Args = GetArgsChecked<typename TArgTypeTraits<ArgType>::Type...>(L, typename TOneBasedIndices<Expected>::Type());
         Construct(L, Args, typename TZeroBasedIndices<Expected>::Type());
         return 1;
     }
@@ -527,7 +535,7 @@ namespace UnLua
             UE_LOG(LogUnLua, Warning, TEXT("Attempted to call %s with invalid arguments. %d expected but got %d."), *Name, Expected, Actual);
             return 0;
         }
-        TTuple<typename TArgTypeTraits<ArgType>::Type...> Args = GetArgs<typename TArgTypeTraits<ArgType>::Type...>(L, typename TOneBasedIndices<Expected>::Type());
+        TTuple<typename TArgTypeTraits<ArgType>::Type...> Args = GetArgsChecked<typename TArgTypeTraits<ArgType>::Type...>(L, typename TOneBasedIndices<Expected>::Type());
         return TInvokingHelper<RetType>::Invoke(L, Func, Args, typename TZeroBasedIndices<Expected>::Type());
     }
 
@@ -579,7 +587,7 @@ namespace UnLua
             UE_LOG(LogUnLua, Warning, TEXT("Attempted to call %s::%s with invalid arguments. %d expected but got %d."), *ClassName, *Name, Expected, Actual);
             return 0;
         }
-        TTuple<ClassType*, typename TArgTypeTraits<ArgType>::Type...> Args = GetArgs<ClassType*, typename TArgTypeTraits<ArgType>::Type...>(L, typename TOneBasedIndices<Expected>::Type());
+        TTuple<ClassType*, typename TArgTypeTraits<ArgType>::Type...> Args = GetArgsChecked<ClassType*, typename TArgTypeTraits<ArgType>::Type...>(L, typename TOneBasedIndices<Expected>::Type());
         if (Args.template Get<0>() == nullptr)
         {
             UE_LOG(LogUnLua, Error, TEXT("Attempted to call %s::%s with nullptr of 'this'."), *ClassName, *Name);

--- a/Plugins/UnLua/Source/UnLua/Public/UnLuaTemplate.h
+++ b/Plugins/UnLua/Source/UnLua/Public/UnLuaTemplate.h
@@ -343,3 +343,33 @@ DEFINE_TYPE(FText)
 DEFINE_SMART_POINTER(TSharedPtr)
 DEFINE_SMART_POINTER(TSharedRef)
 DEFINE_SMART_POINTER(TWeakPtr)
+
+/**
+ * Define container names
+ */
+template<typename ElementType, typename Allocator>
+struct UnLua::TType<TArray<ElementType, Allocator>, false>
+{
+	static const char * GetName()
+	{
+		return "TArray<>";
+	}
+};
+
+template<typename KeyType, typename ValueType, typename SetAllocator, typename KeyFunc>
+struct UnLua::TType<TMap<KeyType, ValueType, SetAllocator, KeyFunc>, false>
+{
+	static const char * GetName()
+	{
+		return "TMap<>";
+	}
+};
+
+template<typename InElementType, typename KeyFunc, typename Allocator>
+struct UnLua::TType<TSet<InElementType, KeyFunc, Allocator>, false>
+{
+	static const char * GetName()
+	{
+		return "TSet<>";
+	}
+};


### PR DESCRIPTION
对于自定义导出的给lua调用的绑定函数，struct值或者引用参数传递nil会直接导致crash，对此情况新增GetArgsChecked接口用于接收参数时做检查以lua error代替直接crash。
---
GetArgs必定奔溃例子：UE.FVector.DistSquared(nil, UE.FVector(0,0,0))