### PR TITLE
修复与继承相关的绑定导致的崩溃和无限循环问题

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Private/LuaFunction.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/LuaFunction.cpp
@@ -32,6 +32,18 @@ DEFINE_FUNCTION(ULuaFunction::execCallLua)
         // PIE 结束时可能已经没有Lua环境了
         return;
     }
+
+    // 如果调用的 ULuaFunction 来自父类，且与对象的 UClass 不是同一个类。
+    // 这就是为什么我们跳过调用 Lua 端，而是调用被重写的函数，以防止继承相关的 bugs
+    if (LuaFunction->GetOverriddenUClass() != Context->GetClass())
+    {
+        const auto Overridden = LuaFunction->GetOverridden();
+        if (Overridden)
+        {
+            Context->CallFunction(Stack, RESULT_PARAM, Overridden);
+        }
+        return;
+    }
     Env->GetFunctionRegistry()->Invoke(LuaFunction, Context, Stack, RESULT_PARAM);
 }
 
@@ -44,6 +56,18 @@ DEFINE_FUNCTION(ULuaFunction::execScriptCallLua)
     if (!Env)
     {
         // PIE 结束时可能已经没有Lua环境了
+        return;
+    }
+
+    // 如果调用的 ULuaFunction 来自父类，且与对象的 UClass 不是同一个类。
+    // 这就是为什么我们跳过调用 Lua 端，而是调用被重写的函数，以防止继承相关的 bugs
+    if (LuaFunction->GetOverriddenUClass() != Context->GetClass())
+    {
+        const auto Overridden = LuaFunction->GetOverridden();
+        if (Overridden)
+        {
+            Context->CallFunction(Stack, RESULT_PARAM, Overridden);
+        }
         return;
     }
     Env->GetFunctionRegistry()->Invoke(LuaFunction, Context, Stack, RESULT_PARAM);


### PR DESCRIPTION
我有 BP_Child 和 BP_Base，它们分别绑定到 Child.lua 和 Base.lua。Child.lua 和 Base.lua 都重写了 FunctionA()。当我在 BP_Child 中调用 FunctionA() 时，它导致了无限循环错误。根本原因是，当执行到 BP_Base 中的 FunctionA 时，由于 Base.lua 重写了 FunctionA()，UnLua 决定再次触发 FunctionA()，这就导致了一个无限循环。你可以看下面的图表来直观理解。

![image](https://github.com/user-attachments/assets/9b3bc218-302b-4345-9ed7-2a9d9c7adf1c)
我在调用 LuaFunction 时添加了检查，判断调用的 ULuaFunction 是否来自父类，且与对象的 UClass 不是同一个类。这就是为什么我们跳过调用 Lua 端，而是调用被重写的函数，以防止继承相关的 bug。
