### PR TITLE
增强UnLua插件对GameFeature插件和普通插件的支持

### DIFF
--- a/Source/UnLua/Private/LuaEnv.cpp
+++ b/Source/UnLua/Private/LuaEnv.cpp
@@ -1,0 +1,981 @@
+﻿// Tencent is pleased to support the open source community by making UnLua available.
+// 
+// Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the MIT License (the "License"); 
+// you may not use this file except in compliance with the License. You may obtain a copy of the License at
+//
+// http://opensource.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, 
+// software distributed under the License is distributed on an "AS IS" BASIS, 
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+// See the License for the specific language governing permissions and limitations under the License.
+
+#include "Engine/World.h"
+#include "Components/InputComponent.h"
+#include "GameFramework/PlayerController.h"
+#include "LuaEnv.h"
+#include "Binding.h"
+#include "LowLevel.h"
+#include "Registries/ObjectRegistry.h"
+#include "Registries/ClassRegistry.h"
+#include "LuaCore.h"
+#include "LuaDynamicBinding.h"
+#include "UELib.h"
+#include "ObjectReferencer.h"
+#include "UnLuaDelegates.h"
+#include "UnLuaInterface.h"
+#include "UnLuaLegacy.h"
+#include "UnLuaLib.h"
+#include "UnLuaSettings.h"
+#include "lstate.h"
+#include "Containers/Queue.h"
+#include "Interfaces/IPluginManager.h"
+#include "HAL/FileManager.h"
+#include "Misc/Paths.h"
+
+// 添加调试定义
+#define UNLUA_DEBUG_PATH 1
+
+namespace UnLua
+{
+    constexpr EInternalObjectFlags AsyncObjectFlags = EInternalObjectFlags::AsyncLoading | EInternalObjectFlags::Async;
+
+    TMap<lua_State*, FLuaEnv*> FLuaEnv::AllEnvs;
+    FLuaEnv::FOnCreated FLuaEnv::OnCreated;
+    FLuaEnv::FOnDestroyed FLuaEnv::OnDestroyed;
+
+#if ENABLE_UNREAL_INSIGHTS && CPUPROFILERTRACE_ENABLED
+    void Hook(lua_State* L, lua_Debug* ar)
+    {
+        static TSet<FName> IgnoreNames{FName("Class"), FName("index"), FName("newindex")};
+
+        lua_getinfo(L, "nSl", ar);
+
+        if (ar->what == FName("Lua"))
+        {
+            if (IgnoreNames.Contains(ar->name))
+            {
+                return;
+            }
+
+            const auto EventName = FString::Printf(TEXT(
+                "%s [%s:%d]"),
+                                                   *FString(ar->name ? ar->name : "N/A"),
+                                                   *FPaths::GetBaseFilename(FString(ar->source)),
+                                                   ar->linedefined);
+
+            if (ar->event == 0)
+            {
+                FCpuProfilerTrace::OutputBeginDynamicEvent(*EventName);
+            }
+            else
+            {
+                FCpuProfilerTrace::OutputEndEvent();
+            }
+        }
+    }
+#endif
+
+    FLuaEnv::FLuaEnv()
+        : bStarted(false)
+    {
+        const auto Settings = GetDefault<UUnLuaSettings>();
+        ModuleLocator = Settings->ModuleLocatorClass.GetDefaultObject();
+        ensureMsgf(ModuleLocator, TEXT("Invalid lua module locator, lua binding will not work properly. please check unlua runtime settings."));
+
+        RegisterDelegates();
+
+#if PLATFORM_WINDOWS
+        // 防止类似AppleProResMedia插件忘了恢复Dll查找目录
+        // https://github.com/Tencent/UnLua/issues/534
+        const auto Dir = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir() / TEXT("Binaries/Win64"));
+        FPlatformProcess::PushDllDirectory(*Dir);
+        L = lua_newstate(GetLuaAllocator(), nullptr);
+        FPlatformProcess::PopDllDirectory(*Dir);
+#else
+        L = lua_newstate(GetLuaAllocator(), nullptr);
+#endif
+
+        AllEnvs.Add(L, this);
+
+        luaL_openlibs(L);
+
+        AddSearcher(LoadFromCustomLoader, 2);
+        AddSearcher(LoadFromFileSystem, 3);
+        AddSearcher(LoadFromBuiltinLibs, 4);
+
+        UELib::Open(L);
+
+        ObjectRegistry = new FObjectRegistry(this);
+        ClassRegistry = new FClassRegistry(this);
+        ClassRegistry->Initialize();
+
+        FunctionRegistry = new FFunctionRegistry(this);
+        DelegateRegistry = new FDelegateRegistry(this);
+        ContainerRegistry = new FContainerRegistry(this);
+        PropertyRegistry = new FPropertyRegistry(this);
+        EnumRegistry = new FEnumRegistry(this);
+        EnumRegistry->Initialize();
+
+        DanglingCheck = new FDanglingCheck(this);
+        DeadLoopCheck = new FDeadLoopCheck(this);
+
+        AutoObjectReference.SetName("UnLua_AutoReference");
+        ManualObjectReference.SetName("UnLua_ManualReference");
+
+        lua_pushstring(L, "StructMap"); // create weak table 'StructMap'
+        LowLevel::CreateWeakValueTable(L);
+        lua_rawset(L, LUA_REGISTRYINDEX);
+
+        lua_pushstring(L, "ArrayMap"); // create weak table 'ArrayMap'
+        LowLevel::CreateWeakValueTable(L);
+        lua_rawset(L, LUA_REGISTRYINDEX);
+
+        if (FUnLuaDelegates::ConfigureLuaGC.IsBound())
+        {
+            FUnLuaDelegates::ConfigureLuaGC.Execute(L);
+        }
+        else
+        {
+#if 504 == LUA_VERSION_NUM
+            lua_gc(L, LUA_GCGEN, 0, 0);
+#else
+            // default Lua GC config in UnLua
+            lua_gc(L, LUA_GCSETPAUSE, 100);
+            lua_gc(L, LUA_GCSETSTEPMUL, 5000);
+#endif
+        }
+
+        FUnLuaDelegates::OnPreStaticallyExport.Broadcast();
+
+        // register statically exported classes
+        auto ExportedNonReflectedClasses = GetExportedNonReflectedClasses();
+        for (const auto& Pair : ExportedNonReflectedClasses)
+            Pair.Value->Register(L);
+
+        // register statically exported global functions
+        auto ExportedFunctions = GetExportedFunctions();
+        for (const auto& Function : ExportedFunctions)
+            Function->Register(L);
+
+        // register statically exported enums
+        auto ExportedEnums = GetExportedEnums();
+        for (const auto& Enum : ExportedEnums)
+            Enum->Register(L);
+
+        UnLuaLib::Open(L);
+
+        OnCreated.Broadcast(*this);
+        FUnLuaDelegates::OnLuaStateCreated.Broadcast(L);
+
+#if ENABLE_UNREAL_INSIGHTS && CPUPROFILERTRACE_ENABLED
+        if (FDeadLoopCheck::Timeout)
+            UE_LOG(LogUnLua, Warning, TEXT("Profiling will not working when DeadLoopCheck enabled."))
+        else
+            lua_sethook(L, Hook, LUA_MASKCALL | LUA_MASKRET, 0);
+#endif
+    }
+
+    FLuaEnv::~FLuaEnv()
+    {
+        OnDestroyed.Broadcast(*this);
+        lua_close(L);
+        AllEnvs.Remove(L);
+
+        delete ClassRegistry;
+        delete ObjectRegistry;
+        delete DelegateRegistry;
+        delete FunctionRegistry;
+        delete ContainerRegistry;
+        delete EnumRegistry;
+        delete PropertyRegistry;
+        delete DanglingCheck;
+        delete DeadLoopCheck;
+
+        if (!IsEngineExitRequested() && Manager)
+        {
+            Manager->Cleanup();
+            Manager->RemoveFromRoot();
+        }
+
+        AutoObjectReference.Clear();
+        ManualObjectReference.Clear();
+
+        UnRegisterDelegates();
+
+        CandidateInputComponents.Empty();
+        FWorldDelegates::OnWorldTickStart.Remove(OnWorldTickStartHandle);
+    }
+
+    TMap<lua_State*, FLuaEnv*>& FLuaEnv::GetAll()
+    {
+        return AllEnvs;
+    }
+
+    FLuaEnv* FLuaEnv::FindEnv(const lua_State* L)
+    {
+        if (!L)
+            return nullptr;
+
+        const auto MainThread = G(L)->mainthread;
+        return AllEnvs.FindRef(MainThread);
+    }
+
+    FLuaEnv& FLuaEnv::FindEnvChecked(const lua_State* L)
+    {
+        return *AllEnvs.FindChecked(G(L)->mainthread);
+    }
+
+    void FLuaEnv::Start(const TMap<FString, UObject*>& Args)
+    {
+        const auto& Setting = *GetDefault<UUnLuaSettings>();
+        Start(Setting.StartupModuleName, Args);
+    }
+
+    void FLuaEnv::Start(const FString& StartupModuleName, const TMap<FString, UObject*>& Args)
+    {
+        if (bStarted)
+            return;
+
+        if (StartupModuleName.IsEmpty())
+        {
+            bStarted = true;
+            return;
+        }
+
+        const auto Guard = GetDeadLoopCheck()->MakeGuard();
+        lua_pushcfunction(L, ReportLuaCallError);
+        lua_getglobal(L, "require");
+        lua_pushstring(L, TCHAR_TO_UTF8(*StartupModuleName));
+        lua_createtable(L, 0, Args.Num());
+        for (auto Pair : Args)
+        {
+            PushUObject(L, Pair.Value);
+            lua_setfield(L, -2, TCHAR_TO_UTF8(*Pair.Key));
+        }
+        lua_pcall(L, 2, LUA_MULTRET, -4);
+        bStarted = true;
+    }
+
+    const FString& FLuaEnv::GetName()
+    {
+        return Name;
+    }
+
+    void FLuaEnv::SetName(FString InName)
+    {
+        Name = InName;
+    }
+
+    void FLuaEnv::NotifyUObjectDeleted(const UObjectBase* ObjectBase, int32 Index)
+    {
+        UObject* Object = (UObject*)ObjectBase;
+        PropertyRegistry->NotifyUObjectDeleted(Object);
+        FunctionRegistry->NotifyUObjectDeleted(Object);
+        if (Manager)
+            Manager->NotifyUObjectDeleted(Object);
+        ObjectRegistry->NotifyUObjectDeleted(Object);
+        ClassRegistry->NotifyUObjectDeleted(Object);
+        EnumRegistry->NotifyUObjectDeleted(Object);
+
+        if (CandidateInputComponents.Num() <= 0)
+            return;
+
+        const int32 NumRemoved = CandidateInputComponents.Remove((UInputComponent*)Object);
+        if (NumRemoved > 0 && CandidateInputComponents.Num() < 1)
+            FWorldDelegates::OnWorldTickStart.Remove(OnWorldTickStartHandle);
+    }
+
+    void FLuaEnv::OnUObjectArrayShutdown()
+    {
+        GUObjectArray.RemoveUObjectDeleteListener(this);
+        bObjectArrayListenerRegistered = false;
+    }
+
+    bool FLuaEnv::TryReplaceInputs(UObject* Object)
+    {
+        if (Object->HasAnyFlags(RF_ClassDefaultObject | RF_ArchetypeObject)
+            || !Object->IsA<UInputComponent>())
+            return false;
+
+        AActor* Actor = Cast<APlayerController>(Object->GetOuter());
+        if (!Actor)
+            Actor = Cast<APawn>(Object->GetOuter());
+
+        if (!Actor)
+            return false;
+
+        CandidateInputComponents.AddUnique((UInputComponent*)Object);
+        if (OnWorldTickStartHandle.IsValid())
+            FWorldDelegates::OnWorldTickStart.Remove(OnWorldTickStartHandle);
+        OnWorldTickStartHandle = FWorldDelegates::OnWorldTickStart.AddRaw(this, &FLuaEnv::OnWorldTickStart);
+        return true;
+    }
+
+    void FLuaEnv::OnWorldTickStart(UWorld* World, ELevelTick TickType, float DeltaTime)
+    {
+        if (!Manager)
+            return;
+
+        for (UInputComponent* InputComponent : CandidateInputComponents)
+        {
+            if (!InputComponent->IsRegistered())
+                continue;
+
+#if ENGINE_MAJOR_VERSION >=5
+            if (!IsValid(InputComponent))
+                continue;
+#else
+            if (InputComponent->IsPendingKill())
+                continue;
+#endif
+
+            AActor* Actor = Cast<AActor>(InputComponent->GetOuter());
+            Manager->ReplaceInputs(Actor, InputComponent); // try to replace/override input events
+        }
+
+        CandidateInputComponents.Empty();
+        FWorldDelegates::OnWorldTickStart.Remove(OnWorldTickStartHandle);
+    }
+
+    bool FLuaEnv::TryBind(UObject* Object)
+    {
+        const auto Class = Object->IsA<UClass>() ? static_cast<UClass*>(Object) : Object->GetClass();
+        if (Class->HasAnyClassFlags(CLASS_NewerVersionExists))
+        {
+            // filter out recompiled objects
+            return false;
+        }
+
+        static UClass* InterfaceClass = UUnLuaInterface::StaticClass();
+        const bool bImplUnluaInterface = Class->ImplementsInterface(InterfaceClass);
+
+        if (IsInAsyncLoadingThread())
+        {
+            // avoid adding too many objects, affecting performance.
+            if (bImplUnluaInterface || (!bImplUnluaInterface && GLuaDynamicBinding.IsValid(Class)))
+            {
+                // all bind operation should be in game thread, include dynamic bind
+                FScopeLock Lock(&CandidatesLock);
+                Candidates.AddUnique(Object);
+                return false;
+            }
+        }
+
+        if (!bImplUnluaInterface)
+        {
+            // dynamic binding
+            if (!GLuaDynamicBinding.IsValid(Class))
+                return false;
+
+            return GetManager()->Bind(Object, *GLuaDynamicBinding.ModuleName, GLuaDynamicBinding.InitializerTableRef);
+        }
+
+        if (Class->GetName().Contains(TEXT("SKEL_")))
+            return false;
+
+        if (!ensureMsgf(ModuleLocator, TEXT("Invalid lua module locator, lua binding will not work properly. please check unlua runtime settings.")))
+            return false;
+
+        const auto ModuleName = ModuleLocator->Locate(Object);
+        if (ModuleName.IsEmpty())
+            return false;
+
+#if !UE_BUILD_SHIPPING
+        if (GLuaDynamicBinding.IsValid(Class) && GLuaDynamicBinding.ModuleName != ModuleName)
+        {
+            UE_LOG(LogUnLua, Warning, TEXT("Dynamic binding '%s' ignored as it conflicts static binding '%s'."), *GLuaDynamicBinding.ModuleName, *ModuleName);
+        }
+#endif
+
+        return GetManager()->Bind(Object, *ModuleName, GLuaDynamicBinding.InitializerTableRef);
+    }
+
+    bool FLuaEnv::DoString(const FString& Chunk, const FString& ChunkName)
+    {
+        const FTCHARToUTF8 ChunkUTF8(*Chunk);
+        const FTCHARToUTF8 ChunkNameUTF8(*ChunkName);
+        const auto Guard = GetDeadLoopCheck()->MakeGuard();
+        const auto DanglingGuard = GetDanglingCheck()->MakeGuard();
+        lua_pushcfunction(L, ReportLuaCallError);
+        const auto MsgHandlerIdx = lua_gettop(L);
+        if (!LoadBuffer(L, ChunkUTF8.Get(), ChunkUTF8.Length(), ChunkNameUTF8.Get()))
+        {
+            lua_pop(L, 1);
+            return false;
+        }
+
+        const auto Result = lua_pcall(L, 0, LUA_MULTRET, MsgHandlerIdx);
+        if (Result == LUA_OK)
+        {
+            lua_remove(L, MsgHandlerIdx);
+            return true;
+        }
+        lua_pop(L, lua_gettop(L) - MsgHandlerIdx + 1);
+        return false;
+    }
+
+    bool FLuaEnv::LoadBuffer(lua_State* InL, const char* Buffer, const size_t Size, const char* InName)
+    {
+        // TODO: env support
+        // TODO: return value support
+
+#if UNLUA_LEGACY_ALLOW_BOM || WITH_EDITOR
+        if (Size > 3 && Buffer[0] == static_cast<char>(0xEF) && Buffer[1] == static_cast<char>(0xBB) && Buffer[2] == static_cast<char>(0xBF))
+        {
+#if !UNLUA_LEGACY_ALLOW_BOM
+            UE_LOG(LogUnLua, Warning, TEXT("Lua chunk with utf-8 BOM:%s"), UTF8_TO_TCHAR(InName));
+#endif
+            return LoadBuffer(InL, Buffer + 3, Size - 3, InName);
+        }
+#endif
+
+        // loads the buffer as a Lua chunk
+        const int32 Code = luaL_loadbufferx(InL, Buffer, Size, InName, nullptr);
+        if (Code != LUA_OK)
+        {
+            UE_LOG(LogUnLua, Warning, TEXT("Failed to call luaL_loadbufferx, error code: %d"), Code);
+            ReportLuaCallError(InL); // report pcall error
+            lua_pushnil(InL); /* error (message is on top of the stack) */
+            lua_insert(InL, -2); /* put before error message */
+            return false;
+        }
+
+        return true;
+    }
+
+    void FLuaEnv::GC()
+    {
+        lua_gc(L, LUA_GCCOLLECT, 0);
+        lua_gc(L, LUA_GCCOLLECT, 0);
+    }
+
+    void FLuaEnv::HotReload()
+    {
+        DoString("UnLua.HotReload()");
+    }
+
+    int32 FLuaEnv::FindThread(const lua_State* Thread)
+    {
+        int32* ThreadRefPtr = ThreadToRef.Find(Thread);
+        return ThreadRefPtr ? *ThreadRefPtr : LUA_REFNIL;
+    }
+
+    void FLuaEnv::ResumeThread(int32 ThreadRef)
+    {
+        lua_State** ThreadPtr = RefToThread.Find(ThreadRef);
+        if (!ThreadPtr)
+            return;
+
+        lua_State* Thread = *ThreadPtr;
+#if 504 == LUA_VERSION_NUM
+        int NResults = 0;
+        int32 Status = lua_resume(Thread, L, 0, &NResults);
+#else
+        int32 Status = lua_resume(Thread, L, 0);
+#endif
+        if (Status == LUA_YIELD)
+            return;
+
+        if (Status != LUA_OK)
+        {
+            const auto ErrMsg = lua_tostring(Thread, -1);
+            UE_LOG(LogUnLua, Error, TEXT("%s"), UTF8_TO_TCHAR(ErrMsg));
+        }
+
+        ThreadToRef.Remove(Thread);
+        RefToThread.Remove(ThreadRef);
+        luaL_unref(L, LUA_REGISTRYINDEX, ThreadRef); // remove the reference if the coroutine finishes its execution
+    }
+
+    UUnLuaManager* FLuaEnv::GetManager()
+    {
+        if (!Manager)
+        {
+            Manager = NewObject<UUnLuaManager>();
+            Manager->Env = this;
+            Manager->AddToRoot();
+        }
+        return Manager;
+    }
+
+    void FLuaEnv::AddThread(lua_State* Thread, int32 ThreadRef)
+    {
+        ThreadToRef.Add(Thread, ThreadRef);
+        RefToThread.Add(ThreadRef, Thread);
+    }
+
+    int32 FLuaEnv::FindOrAddThread(lua_State* Thread)
+    {
+        int32 ThreadRef = FindThread(Thread);
+        if (ThreadRef == LUA_REFNIL)
+        {
+            int32 Value = lua_pushthread(Thread);
+            if (Value == 1)
+            {
+                lua_pop(Thread, 1);
+                return LUA_REFNIL;
+            }
+
+            ThreadRef = luaL_ref(Thread, LUA_REGISTRYINDEX);
+            AddThread(Thread, ThreadRef);
+        }
+        return ThreadRef;
+    }
+
+    lua_Alloc FLuaEnv::GetLuaAllocator() const
+    {
+        return DefaultLuaAllocator;
+    }
+
+    void FLuaEnv::AddLoader(const FLuaFileLoader Loader)
+    {
+        CustomLoaders.Add(Loader);
+    }
+
+    void FLuaEnv::AddBuiltInLoader(const FString InName, const lua_CFunction Loader)
+    {
+        BuiltinLoaders.Add(InName, Loader);
+    }
+
+    void FLuaEnv::AddManualObjectReference(UObject* Object)
+    {
+        ManualObjectReference.Add(Object);
+    }
+
+    void FLuaEnv::RemoveManualObjectReference(UObject* Object)
+    {
+        ManualObjectReference.Remove(Object);
+    }
+
+    int FLuaEnv::LoadFromBuiltinLibs(lua_State* L)
+    {
+        const FLuaEnv* Env = (FLuaEnv*)lua_touserdata(L, lua_upvalueindex(1));
+        const FString Name = UTF8_TO_TCHAR(lua_tostring(L, 1));
+        const auto Loader = Env->BuiltinLoaders.Find(Name);
+        if (!Loader)
+            return 0;
+        lua_pushcfunction(L, *Loader);
+        return 1;
+    }
+
+    int FLuaEnv::LoadFromCustomLoader(lua_State* L)
+    {
+        auto& Env = *(FLuaEnv*)lua_touserdata(L, lua_upvalueindex(1));
+        if (FUnLuaDelegates::CustomLoadLuaFile.IsBound())
+        {
+            // legacy support
+            const FString FileName(UTF8_TO_TCHAR(lua_tostring(L, 1)));
+            TArray<uint8> Data;
+            FString ChunkName(TEXT("chunk"));
+            if (FUnLuaDelegates::CustomLoadLuaFile.Execute(Env, FileName, Data, ChunkName))
+            {
+                if (Env.LoadString(L, Data, ChunkName))
+                    return 1;
+
+                return luaL_error(L, "file loading from custom loader error");
+            }
+            return 0;
+        }
+
+        if (Env.CustomLoaders.Num() == 0)
+            return 0;
+
+        const FString FileName(UTF8_TO_TCHAR(lua_tostring(L, 1)));
+
+        TArray<uint8> Data;
+        FString ChunkName(TEXT("chunk"));
+        for (auto& Loader : Env.CustomLoaders)
+        {
+            if (!Loader.Execute(Env, FileName, Data, ChunkName))
+                continue;
+
+            if (Env.LoadString(L, Data, ChunkName))
+                break;
+
+            return luaL_error(L, "file loading from custom loader error");
+        }
+
+        return 1;
+    }
+
+    int FLuaEnv::LoadFromFileSystem(lua_State* L)
+    {
+        FString FileName(UTF8_TO_TCHAR(lua_tostring(L, 1)));
+        FileName.ReplaceInline(TEXT("."), TEXT("/"));
+
+#if UNLUA_DEBUG_PATH
+        UE_LOG(LogUnLua, Display, TEXT("[UnLua] LoadFromFileSystem - Trying to load module: %s"), *FileName);
+#endif
+
+        auto& Env = *(FLuaEnv*)lua_touserdata(L, lua_upvalueindex(1));
+        TArray<uint8> Data;
+        FString FullPath;
+
+        auto LoadIt = [&]
+        {
+#if UNLUA_DEBUG_PATH
+            UE_LOG(LogUnLua, Display, TEXT("[UnLua] LoadFromFileSystem - Successfully loaded file: %s"), *FullPath);
+#endif
+            if (Env.LoadString(L, Data, FullPath))
+                return 1;
+            const auto Msg = FString::Printf(TEXT("file loading from file system error.\nfull path:%s"), *FullPath);
+            return luaL_error(L, TCHAR_TO_UTF8(*Msg));
+        };
+
+        const auto PackagePath = UnLuaLib::GetPackagePath(L);
+        if (PackagePath.IsEmpty())
+            return 0;
+
+#if UNLUA_DEBUG_PATH
+        UE_LOG(LogUnLua, Display, TEXT("[UnLua] LoadFromFileSystem - Package path: %s"), *PackagePath);
+#endif
+
+        TArray<FString> Patterns;
+        if (PackagePath.ParseIntoArray(Patterns, TEXT(";"), false) == 0)
+            return 0;
+
+#if UNLUA_DEBUG_PATH
+        UE_LOG(LogUnLua, Display, TEXT("[UnLua] LoadFromFileSystem - Found %d patterns"), Patterns.Num());
+#endif
+
+        // 特殊处理 GameFeature 插件路径
+        // 如果是PluginName.ModuleName这样的模块格式，尝试直接定位到对应插件
+        if (FileName.Contains(TEXT("/")))
+        {
+            TArray<FString> ModuleParts;
+            FileName.ParseIntoArray(ModuleParts, TEXT("/"));
+            
+            if (ModuleParts.Num() >= 2)
+            {
+                FString PluginName = ModuleParts[0];
+                FString ModuleFile = ModuleParts[ModuleParts.Num() - 1];
+                
+#if UNLUA_DEBUG_PATH
+                UE_LOG(LogUnLua, Display, TEXT("[UnLua] LoadFromFileSystem - Searching for module in plugin - Plugin: %s, Module: %s"), 
+                       *PluginName, *ModuleFile);
+#endif
+
+                // 尝试在GameFeature插件中查找
+                FString GameFeaturePath = FPaths::Combine(
+                    FPaths::ProjectPluginsDir(),
+                    TEXT("GameFeatures"),
+                    PluginName,
+                    TEXT("Content/Script"),
+                    PluginName,
+                    ModuleFile + TEXT(".lua")
+                );
+                
+                FullPath = FPaths::ConvertRelativePathToFull(GameFeaturePath);
+                
+#if UNLUA_DEBUG_PATH
+                UE_LOG(LogUnLua, Display, TEXT("[UnLua] LoadFromFileSystem - Checking GameFeature plugin path: %s"), *FullPath);
+#endif
+                
+                if (FPaths::FileExists(FullPath) && FFileHelper::LoadFileToArray(Data, *FullPath, FILEREAD_Silent))
+                {
+                    return LoadIt();
+                }
+                
+                // 尝试在普通插件中查找
+                FString NormalPluginPath = FPaths::Combine(
+                    FPaths::ProjectPluginsDir(),
+                    PluginName,
+                    TEXT("Content/Script"),
+                    PluginName,
+                    ModuleFile + TEXT(".lua")
+                );
+                
+                FullPath = FPaths::ConvertRelativePathToFull(NormalPluginPath);
+                
+#if UNLUA_DEBUG_PATH
+                UE_LOG(LogUnLua, Display, TEXT("[UnLua] LoadFromFileSystem - Checking normal plugin path: %s"), *FullPath);
+#endif
+                
+                if (FPaths::FileExists(FullPath) && FFileHelper::LoadFileToArray(Data, *FullPath, FILEREAD_Silent))
+                {
+                    return LoadIt();
+                }
+                
+                // 尝试第二种常见结构 - 直接在Content/Script下
+                FString DirectPath = FPaths::Combine(
+                    FPaths::ProjectPluginsDir(),
+                    TEXT("GameFeatures"),
+                    PluginName,
+                    TEXT("Content/Script"),
+                    ModuleFile + TEXT(".lua")
+                );
+                
+                FullPath = FPaths::ConvertRelativePathToFull(DirectPath);
+                
+#if UNLUA_DEBUG_PATH
+                UE_LOG(LogUnLua, Display, TEXT("[UnLua] LoadFromFileSystem - Checking direct GameFeature path: %s"), *FullPath);
+#endif
+                
+                if (FPaths::FileExists(FullPath) && FFileHelper::LoadFileToArray(Data, *FullPath, FILEREAD_Silent))
+                {
+                    return LoadIt();
+                }
+                
+                // 尝试普通插件的直接路径
+                FString DirectNormalPath = FPaths::Combine(
+                    FPaths::ProjectPluginsDir(),
+                    PluginName,
+                    TEXT("Content/Script"),
+                    ModuleFile + TEXT(".lua")
+                );
+                
+                FullPath = FPaths::ConvertRelativePathToFull(DirectNormalPath);
+                
+#if UNLUA_DEBUG_PATH
+                UE_LOG(LogUnLua, Display, TEXT("[UnLua] LoadFromFileSystem - Checking direct normal plugin path: %s"), *FullPath);
+#endif
+                
+                if (FPaths::FileExists(FullPath) && FFileHelper::LoadFileToArray(Data, *FullPath, FILEREAD_Silent))
+                {
+                    return LoadIt();
+                }
+            }
+        }
+
+        // 优先加载下载目录下的单文件
+        for (auto& Pattern : Patterns)
+        {
+            // 处理通配符路径，例如Plugins/*/Content/Script
+            bool bHasWildcard = Pattern.Contains(TEXT("*"));
+            if (bHasWildcard)
+            {
+                // 找到通配符位置
+                int32 WildcardPos = Pattern.Find(TEXT("*"));
+                if (WildcardPos != INDEX_NONE)
+                {
+                    FString PreWildcard = Pattern.Left(WildcardPos);
+                    FString PostWildcard = Pattern.Mid(WildcardPos + 1);
+                    
+                    // 替换问号为文件名
+                    FString FilePartPattern = PostWildcard;
+                    FilePartPattern.ReplaceInline(TEXT("?"), *FileName);
+                    
+                    // 获取插件目录
+                    IFileManager& FileManager = IFileManager::Get();
+                    TArray<FString> Plugins;
+                    
+                    // 判断是GameFeature插件还是普通插件
+                    FString PluginsRoot;
+                    if (PreWildcard.Contains(TEXT("GameFeatures")))
+                    {
+                        PluginsRoot = FPaths::ProjectPluginsDir() / TEXT("GameFeatures");
+                    }
+                    else
+                    {
+                        PluginsRoot = FPaths::ProjectPluginsDir();
+                    }
+                    
+                    // 获取所有插件目录
+                    FileManager.FindFiles(Plugins, *PluginsRoot, false, true);
+                    
+                    // 检查每个插件目录下的文件
+                    for (const FString& Plugin : Plugins)
+                    {
+                        FString TestPath = FPaths::Combine(PluginsRoot, Plugin, FilePartPattern);
+                        FullPath = FPaths::ConvertRelativePathToFull(TestPath);
+                        
+                        if (FFileHelper::LoadFileToArray(Data, *FullPath, FILEREAD_Silent))
+                            return LoadIt();
+                    }
+                    
+                    // 找不到文件时继续下一个模式
+                    continue;
+                }
+            }
+            
+            // 处理标准路径
+            Pattern.ReplaceInline(TEXT("?"), *FileName);
+            const auto PathWithPersistentDir = FPaths::Combine(FPaths::ProjectPersistentDownloadDir(), Pattern);
+            FullPath = FPaths::ConvertRelativePathToFull(PathWithPersistentDir);
+            if (FFileHelper::LoadFileToArray(Data, *FullPath, FILEREAD_Silent))
+                return LoadIt();
+        }
+
+        // 其次是打包目录下的文件
+        for (auto& Pattern : Patterns)
+        {
+            // 同样处理通配符路径
+            bool bHasWildcard = Pattern.Contains(TEXT("*"));
+            if (bHasWildcard)
+            {
+                // 找到通配符位置
+                int32 WildcardPos = Pattern.Find(TEXT("*"));
+                if (WildcardPos != INDEX_NONE)
+                {
+                    FString PreWildcard = Pattern.Left(WildcardPos);
+                    FString PostWildcard = Pattern.Mid(WildcardPos + 1);
+                    
+                    // 替换问号为文件名
+                    FString FilePartPattern = PostWildcard;
+                    FilePartPattern.ReplaceInline(TEXT("?"), *FileName);
+                    
+                    // 获取插件目录
+                    IFileManager& FileManager = IFileManager::Get();
+                    TArray<FString> Plugins;
+                    
+                    // 判断是GameFeature插件还是普通插件
+                    FString PluginsRoot;
+                    if (PreWildcard.Contains(TEXT("GameFeatures")))
+                    {
+                        PluginsRoot = FPaths::ProjectPluginsDir() / TEXT("GameFeatures");
+                    }
+                    else
+                    {
+                        PluginsRoot = FPaths::ProjectPluginsDir();
+                    }
+                    
+                    // 获取所有插件目录
+                    FileManager.FindFiles(Plugins, *PluginsRoot, false, true);
+                    
+                    // 检查每个插件目录下的文件
+                    for (const FString& Plugin : Plugins)
+                    {
+                        FString TestPath = FPaths::Combine(FPaths::ProjectDir(), PreWildcard, Plugin, FilePartPattern);
+                        FullPath = FPaths::ConvertRelativePathToFull(TestPath);
+                        
+                        if (FFileHelper::LoadFileToArray(Data, *FullPath, FILEREAD_Silent))
+                            return LoadIt();
+                    }
+                    
+                    // 找不到文件时继续下一个模式
+                    continue;
+                }
+            }
+            
+            // 处理标准路径
+            const auto PathWithProjectDir = FPaths::Combine(FPaths::ProjectDir(), Pattern);
+            FullPath = FPaths::ConvertRelativePathToFull(PathWithProjectDir);
+            if (FFileHelper::LoadFileToArray(Data, *FullPath, FILEREAD_Silent))
+                return LoadIt();
+        }
+        
+#if UNLUA_DEBUG_PATH
+        UE_LOG(LogUnLua, Warning, TEXT("[UnLua] LoadFromFileSystem - File not found: %s"), *FileName);
+#endif
+        return 0;
+    }
+
+    void FLuaEnv::AddSearcher(lua_CFunction Searcher, int Index) const
+    {
+        lua_getglobal(L, "package");
+        lua_getfield(L, -1, "searchers");
+        lua_remove(L, -2);
+        if (!lua_istable(L, -1))
+        {
+            UE_LOG(LogUnLua, Warning, TEXT("Invalid package.serachers!"));
+            return;
+        }
+
+        const uint32 Len = lua_rawlen(L, -1);
+        Index = Index < 0 ? (int)(Len + Index + 2) : Index;
+        for (int e = (int)Len + 1; e > Index; e--)
+        {
+            lua_rawgeti(L, -1, e - 1);
+            lua_rawseti(L, -2, e);
+        }
+
+        lua_pushlightuserdata(L, (void*)this);
+        lua_pushcclosure(L, Searcher, 1);
+        lua_rawseti(L, -2, Index);
+        lua_pop(L, 1);
+    }
+
+    void FLuaEnv::OnAsyncLoadingFlushUpdate()
+    {
+        TArray<FWeakObjectPtr> CandidatesTemp;
+        TArray<int> CandidatesRemovedIndexes;
+
+        TArray<UObject*> LocalCandidates;
+        {
+            {
+                FScopeLock Lock(&CandidatesLock);
+                CandidatesTemp.Append(Candidates);
+            }
+
+
+            for (int32 i = CandidatesTemp.Num() - 1; i >= 0; --i)
+            {
+                FWeakObjectPtr ObjectPtr = CandidatesTemp[i];
+                if (!ObjectPtr.IsValid())
+                {
+                    // discard invalid objects
+                    CandidatesRemovedIndexes.Add(i);
+                    continue;
+                }
+
+                UObject* Object = ObjectPtr.Get();
+                if (Object->HasAnyFlags(RF_NeedPostLoad)
+                    || Object->HasAnyInternalFlags(AsyncObjectFlags)
+                    || Object->GetClass()->HasAnyInternalFlags(AsyncObjectFlags))
+                {
+                    // delay bind on next update 
+                    continue;
+                }
+
+                LocalCandidates.Add(Object);
+                CandidatesRemovedIndexes.Add(i);
+            }
+        }
+
+        {
+            FScopeLock Lock(&CandidatesLock);
+            for (int32 j = 0; j < CandidatesRemovedIndexes.Num(); ++j)
+            {
+                Candidates.RemoveAt(CandidatesRemovedIndexes[j]);
+            }
+        }
+
+        for (int32 i = 0; i < LocalCandidates.Num(); ++i)
+        {
+            UObject* Object = LocalCandidates[i];
+            TryBind(Object);
+        }
+    }
+
+    FORCEINLINE void FLuaEnv::RegisterDelegates()
+    {
+        OnAsyncLoadingFlushUpdateHandle = FCoreDelegates::OnAsyncLoadingFlushUpdate.AddRaw(this, &FLuaEnv::OnAsyncLoadingFlushUpdate);
+        GUObjectArray.AddUObjectDeleteListener(this);
+        bObjectArrayListenerRegistered = true;
+    }
+
+    FORCEINLINE void FLuaEnv::UnRegisterDelegates()
+    {
+        FCoreDelegates::OnAsyncLoadingFlushUpdate.Remove(OnAsyncLoadingFlushUpdateHandle);
+        if (!bObjectArrayListenerRegistered)
+            return;
+        GUObjectArray.RemoveUObjectDeleteListener(this);
+        bObjectArrayListenerRegistered = false;
+    }
+
+    void* FLuaEnv::DefaultLuaAllocator(void* ud, void* ptr, size_t osize, size_t nsize)
+    {
+        if (nsize == 0)
+        {
+            UNLUA_STAT_MEMORY_FREE(ptr, Lua);
+            FMemory::Free(ptr);
+            return nullptr;
+        }
+
+        void* Buffer;
+        if (!ptr)
+        {
+            Buffer = FMemory::Malloc(nsize);
+            UNLUA_STAT_MEMORY_ALLOC(Buffer, Lua);
+        }
+        else
+        {
+            UNLUA_STAT_MEMORY_REALLOC(ptr, Buffer, Lua);
+            Buffer = FMemory::Realloc(ptr, nsize);
+        }
+        return Buffer;
+    }
+}

--- a/Source/UnLua/Private/LuaModuleLocator.cpp
+++ b/Source/UnLua/Private/LuaModuleLocator.cpp
@@ -1,0 +1,154 @@
+﻿// Tencent is pleased to support the open source community by making UnLua available.
+// 
+// Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the MIT License (the "License"); 
+// you may not use this file except in compliance with the License. You may obtain a copy of the License at
+//
+// http://opensource.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, 
+// software distributed under the License is distributed on an "AS IS" BASIS, 
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+// See the License for the specific language governing permissions and limitations under the License.
+
+#include "LuaModuleLocator.h"
+#include "UnLuaInterface.h"
+
+FString ULuaModuleLocator::Locate(const UObject* Object)
+{
+    const UObject* CDO;
+    if (Object->HasAnyFlags(RF_ClassDefaultObject | RF_ArchetypeObject))
+    {
+        CDO = Object;
+    }
+    else
+    {
+        const auto Class = Cast<UClass>(Object);
+        CDO = Class ? Class->GetDefaultObject() : Object->GetClass()->GetDefaultObject();
+    }
+
+    if (CDO->HasAnyFlags(RF_NeedInitialization))
+    {
+        // CDO还没有初始化完成
+        return "";
+    }
+
+    if (!CDO->GetClass()->ImplementsInterface(UUnLuaInterface::StaticClass()))
+    {
+        return "";
+    }
+
+    return IUnLuaInterface::Execute_GetModuleName(CDO);
+}
+
+FString ULuaModuleLocator_ByPackage::Locate(const UObject* Object)
+{
+    const auto Class = Object->IsA<UClass>() ? static_cast<const UClass*>(Object) : Object->GetClass();
+    const auto Key = Class->GetFName();
+    const auto Cached = Cache.Find(Key);
+    if (Cached)
+        return *Cached;
+
+    FString ModuleName;
+    if (Class->IsNative())
+    {
+        ModuleName = Class->GetName();
+    }
+    else
+    {
+        FString OuterName = Object->GetOutermost()->GetName();
+        
+        // 检查是否来自GameFeature插件
+        const bool bFromGameFeature = OuterName.Contains(TEXT("/GameFeatures/"));
+        const bool bFromPlugin = OuterName.Contains(TEXT("/Plugins/"));
+        
+        if (bFromGameFeature || bFromPlugin)
+        {
+            // 提取插件名称
+            FString PluginName;
+            int32 PluginPathPos = INDEX_NONE;
+            
+            if (bFromGameFeature)
+            {
+                // 处理 GameFeature 插件
+                const int32 GameFeaturesPos = OuterName.Find(TEXT("/GameFeatures/"), ESearchCase::IgnoreCase);
+                if (GameFeaturesPos != INDEX_NONE)
+                {
+                    const int32 StartPos = GameFeaturesPos + FString(TEXT("/GameFeatures/")).Len();
+                    const int32 EndPos = OuterName.Find(TEXT("/"), ESearchCase::IgnoreCase, ESearchDir::FromStart, StartPos);
+                    if (EndPos != INDEX_NONE)
+                    {
+                        PluginName = OuterName.Mid(StartPos, EndPos - StartPos);
+                        PluginPathPos = GameFeaturesPos;
+                    }
+                }
+            }
+            else if (bFromPlugin)
+            {
+                // 处理普通插件
+                const int32 PluginsPos = OuterName.Find(TEXT("/Plugins/"), ESearchCase::IgnoreCase);
+                if (PluginsPos != INDEX_NONE)
+                {
+                    const int32 StartPos = PluginsPos + FString(TEXT("/Plugins/")).Len();
+                    const int32 EndPos = OuterName.Find(TEXT("/"), ESearchCase::IgnoreCase, ESearchDir::FromStart, StartPos);
+                    if (EndPos != INDEX_NONE)
+                    {
+                        PluginName = OuterName.Mid(StartPos, EndPos - StartPos);
+                        PluginPathPos = PluginsPos;
+                    }
+                }
+            }
+            
+            // 处理插件中的蓝图
+            if (!PluginName.IsEmpty() && PluginPathPos != INDEX_NONE)
+            {
+                // 获取资源路径部分
+                FString ResourcePath;
+                const int32 ContentPos = OuterName.Find(TEXT("/Content/"), ESearchCase::IgnoreCase, ESearchDir::FromStart, PluginPathPos);
+                if (ContentPos != INDEX_NONE)
+                {
+                    const int32 ScriptPartStart = ContentPos + FString(TEXT("/Content/")).Len();
+                    ResourcePath = OuterName.Mid(ScriptPartStart);
+                    
+                    // 获取类名部分（最后一个斜杠后的部分）
+                    FString ClassName;
+                    const int32 LastSlashPos = ResourcePath.Find(TEXT("/"), ESearchCase::IgnoreCase, ESearchDir::FromEnd);
+                    if (LastSlashPos != INDEX_NONE)
+                    {
+                        ClassName = ResourcePath.Mid(LastSlashPos + 1);
+                        
+                        // 构建最终的模块名
+                        // 对于GameFeature插件，使用: 插件名.类名
+                        // 例如: AstraAI.BP_TEST_C
+                        ModuleName = PluginName + TEXT(".") + ClassName;
+                    }
+                    else
+                    {
+                        ModuleName = PluginName + TEXT(".") + ResourcePath;
+                    }
+                }
+                else
+                {
+                    // 如果找不到Content目录，使用类名
+                    ModuleName = PluginName + TEXT(".") + Class->GetName();
+                }
+            }
+            else
+            {
+                // 使用默认处理
+                const auto ChopCount = OuterName.Find(TEXT("/"), ESearchCase::IgnoreCase, ESearchDir::FromStart, 1) + 1;
+                ModuleName = OuterName.Replace(TEXT("/"), TEXT(".")).RightChop(ChopCount);
+            }
+        }
+        else
+        {
+            // 普通资产的处理方式（不变）
+            const auto ChopCount = OuterName.Find(TEXT("/"), ESearchCase::IgnoreCase, ESearchDir::FromStart, 1) + 1;
+            ModuleName = OuterName.Replace(TEXT("/"), TEXT(".")).RightChop(ChopCount);
+        }
+    }
+    
+    Cache.Add(Key, ModuleName);
+    return ModuleName;
+}

--- a/Source/UnLua/Private/UnLuaLib.cpp
+++ b/Source/UnLua/Private/UnLuaLib.cpp
@@ -1,0 +1,321 @@
+#include "UnLuaLib.h"
+#include "LowLevel.h"
+#include "LuaEnv.h"
+#include "UnLuaBase.h"
+#include "Misc/Paths.h"
+#include "Misc/App.h"
+
+// 在开头添加DEBUG标志，用于调试
+#define UNLUA_DEBUG_PATH 1
+
+namespace UnLua
+{
+    namespace UnLuaLib
+    {
+        static const char* PACKAGE_PATH_KEY = "PackagePath";
+
+        static FString GetMessage(lua_State* L)
+        {
+            const auto ArgCount = lua_gettop(L);
+            FString Message;
+            if (!lua_checkstack(L, ArgCount))
+            {
+                luaL_error(L, "too many arguments, stack overflow");
+                return Message;
+            }
+            for (int ArgIndex = 1; ArgIndex <= ArgCount; ArgIndex++)
+            {
+                if (ArgIndex > 1)
+                    Message += "\t";
+                Message += UTF8_TO_TCHAR(luaL_tolstring(L, ArgIndex, NULL));
+            }
+            return Message;
+        }
+
+        static int LogInfo(lua_State* L)
+        {
+            const auto Msg = GetMessage(L);
+            UE_LOG(LogUnLua, Log, TEXT("%s"), *Msg);
+            return 0;
+        }
+
+        static int LogWarn(lua_State* L)
+        {
+            const auto Msg = GetMessage(L);
+            UE_LOG(LogUnLua, Warning, TEXT("%s"), *Msg);
+            return 0;
+        }
+
+        static int LogError(lua_State* L)
+        {
+            const auto Msg = GetMessage(L);
+            UE_LOG(LogUnLua, Error, TEXT("%s"), *Msg);
+            return 0;
+        }
+
+        static int HotReload(lua_State* L)
+        {
+#if UNLUA_WITH_HOT_RELOAD
+            if (luaL_dostring(L, "require('UnLua.HotReload').reload()") != 0)
+            {
+                LogError(L);
+            }
+#endif
+            return 0;
+        }
+
+        static int Ref(lua_State* L)
+        {
+            const auto Object = GetUObject(L, -1);
+            if (!Object)
+                return luaL_error(L, "invalid UObject");
+
+            const auto& Env = FLuaEnv::FindEnvChecked(L);
+            Env.GetObjectRegistry()->AddManualRef(L, Object);
+            return 1;
+        }
+
+        static int Unref(lua_State* L)
+        {
+            const auto Object = GetUObject(L, -1);
+            if (!Object)
+                return luaL_error(L, "invalid UObject");
+
+            const auto& Env = FLuaEnv::FindEnvChecked(L);
+            Env.GetObjectRegistry()->RemoveManualRef(Object);
+            return 0;
+        }
+
+        static constexpr luaL_Reg UnLua_Functions[] = {
+            {"Log", LogInfo},
+            {"LogWarn", LogWarn},
+            {"LogError", LogError},
+            {"HotReload", HotReload},
+            {"Ref", Ref},
+            {"Unref", Unref},
+            {"FTextEnabled", nullptr},
+            {NULL, NULL}
+        };
+
+#pragma region Legacy Support
+
+        int32 GetUProperty(lua_State* L)
+        {
+            auto Ptr = lua_touserdata(L, 2);
+            if (!Ptr)
+                return 0;
+
+            auto Property = static_cast<TSharedPtr<UnLua::ITypeOps>*>(Ptr);
+            if (!Property->IsValid())
+                return 0;
+
+            auto Self = GetCppInstance(L, 1);
+            if (!Self)
+                return 0;
+
+            if (UnLua::LowLevel::IsReleasedPtr(Self))
+                return luaL_error(L, TCHAR_TO_UTF8(*FString::Printf(TEXT("attempt to read property '%s' on released object"), *(*Property)->GetName())));
+
+            if (!LowLevel::CheckPropertyOwner(L, (*Property).Get(), Self))
+                return 0;
+
+            (*Property)->ReadValue_InContainer(L, Self, false);
+            return 1;
+        }
+
+        int32 SetUProperty(lua_State* L)
+        {
+            auto Ptr = lua_touserdata(L, 2);
+            if (!Ptr)
+                return 0;
+
+            auto Property = static_cast<TSharedPtr<UnLua::ITypeOps>*>(Ptr);
+            if (!Property->IsValid())
+                return 0;
+
+            auto Self = GetCppInstance(L, 1);
+            if (LowLevel::IsReleasedPtr(Self))
+                return luaL_error(L, TCHAR_TO_UTF8(*FString::Printf(TEXT("attempt to write property '%s' on released object"), *(*Property)->GetName())));
+
+            if (!LowLevel::CheckPropertyOwner(L, (*Property).Get(), Self))
+                return 0;
+
+            (*Property)->WriteValue_InContainer(L, Self, 3);
+            return 0;
+        }
+
+        static constexpr luaL_Reg UnLua_LegacyFunctions[] = {
+            {"GetUProperty", GetUProperty},
+            {"SetUProperty", SetUProperty},
+            {NULL, NULL}
+        };
+
+        static void LegacySupport(lua_State* L)
+        {
+            static const char* Chunk = R"(
+            local rawget = _G.rawget
+            local rawset = _G.rawset
+            local rawequal = _G.rawequal
+            local type = _G.type
+            local getmetatable = _G.getmetatable
+            local require = _G.require
+
+            local GetUProperty = GetUProperty
+            local SetUProperty = SetUProperty
+
+            local NotExist = {}
+
+            local function Index(t, k)
+                local mt = getmetatable(t)
+                local super = mt
+                while super do
+                    local v = rawget(super, k)
+                    if v ~= nil and not rawequal(v, NotExist) then
+                        rawset(t, k, v)
+                        return v
+                    end
+                    super = rawget(super, "Super")
+                end
+
+                local p = mt[k]
+                if p ~= nil then
+                    if type(p) == "userdata" then
+                        return GetUProperty(t, p)
+                    elseif type(p) == "function" then
+                        rawset(t, k, p)
+                    elseif rawequal(p, NotExist) then
+                        return nil
+                    end
+                else
+                    rawset(mt, k, NotExist)
+                end
+
+                return p
+            end
+
+            local function NewIndex(t, k, v)
+                local mt = getmetatable(t)
+                local p = mt[k]
+                if type(p) == "userdata" then
+                    return SetUProperty(t, p, v)
+                end
+                rawset(t, k, v)
+            end
+
+            local function Class(super_name)
+                local super_class = nil
+                if super_name ~= nil then
+                    super_class = require(super_name)
+                end
+
+                local new_class = {}
+                new_class.__index = Index
+                new_class.__newindex = NewIndex
+                new_class.Super = super_class
+
+              return new_class
+            end
+
+            _G.Class = Class
+            _G.GetUProperty = GetUProperty
+            _G.SetUProperty = SetUProperty
+            )";
+
+            lua_register(L, "UEPrint", LogInfo);
+            luaL_loadstring(L, Chunk);
+            lua_newtable(L);
+            lua_getglobal(L, LUA_GNAME);
+            lua_setfield(L, -2, LUA_GNAME);
+            luaL_setfuncs(L, UnLua_LegacyFunctions, 0);
+            lua_setupvalue(L, -2, 1);
+            lua_pcall(L, 0, LUA_MULTRET, 0);
+            lua_getglobal(L, "Class");
+            lua_setfield(L, -2, "Class");
+        }
+
+#pragma endregion
+
+        static int LuaOpen(lua_State* L)
+        {
+            lua_newtable(L);
+            luaL_setfuncs(L, UnLua_Functions, 0);
+            
+            // 生成完整的默认搜索路径
+            FString ProjectContentPath = "Content/Script/?.lua;";
+            FString PluginBasePath = "Plugins/UnLua/Content/Script/?.lua;";
+            FString PluginsPath = "Plugins/*/Content/Script/?.lua;";
+            FString GameFeaturesPath = "Plugins/GameFeatures/*/Content/Script/?.lua";
+            
+            // 完整的搜索路径
+            FString FullPackagePath = ProjectContentPath + PluginBasePath + PluginsPath + GameFeaturesPath;
+            
+#if UNLUA_DEBUG_PATH
+            // 输出搜索路径信息以便调试
+            UE_LOG(LogUnLua, Display, TEXT("=================== UnLua Package Path =================="));
+            UE_LOG(LogUnLua, Display, TEXT("Setting PackagePath: %s"), *FullPackagePath);
+            UE_LOG(LogUnLua, Display, TEXT("Project Dir: %s"), *FPaths::ProjectDir());
+            UE_LOG(LogUnLua, Display, TEXT("Engine Dir: %s"), *FPaths::EngineDir());
+            UE_LOG(LogUnLua, Display, TEXT("========================================================="));
+#endif
+            
+            lua_pushstring(L, TCHAR_TO_UTF8(*FullPackagePath));
+            lua_setfield(L, -2, PACKAGE_PATH_KEY);
+            return 1;
+        }
+
+        int Open(lua_State* L)
+        {
+            lua_register(L, "print", LogInfo);
+            luaL_requiref(L, "UnLua", LuaOpen, 1);
+            luaL_dostring(L, R"(
+                setmetatable(UnLua, {
+                    __index = function(t, k)
+                        local ok, result = pcall(require, "UnLua." .. tostring(k))
+                        if ok then
+                            rawset(t, k, result)
+                            return result
+                        else
+                            t.LogWarn(string.format("failed to load module UnLua.%s\n%s", k, result))
+                        end
+                    end
+                })
+            )");
+
+#if UNLUA_ENABLE_FTEXT
+            luaL_dostring(L, "UnLua.FTextEnabled = true");
+#else
+            luaL_dostring(L, "UnLua.FTextEnabled = false");
+#endif
+
+#if UNLUA_WITH_HOT_RELOAD
+            luaL_dostring(L, R"(
+                pcall(function() _G.require = require('UnLua.HotReload').require end)
+            )");
+#endif
+
+            LegacySupport(L);
+            lua_pop(L, 1);
+            return 1;
+        }
+
+        FString GetPackagePath(lua_State* L)
+        {
+            lua_getglobal(L, "UnLua");
+            checkf(lua_istable(L, -1), TEXT("UnLuaLib not registered"));
+            lua_getfield(L, -1, PACKAGE_PATH_KEY);
+            const auto PackagePath = lua_tostring(L, -1);
+            checkf(PackagePath, TEXT("invalid PackagePath"));
+            lua_pop(L, 2);
+            return UTF8_TO_TCHAR(PackagePath);
+        }
+
+        void SetPackagePath(lua_State* L, const FString& PackagePath)
+        {
+            lua_getglobal(L, "UnLua");
+            checkf(lua_istable(L, -1), TEXT("UnLuaLib not registered"));
+            lua_pushstring(L, TCHAR_TO_UTF8(*PackagePath));
+            lua_setfield(L, -2, PACKAGE_PATH_KEY);
+            lua_pop(L, 2);
+        }
+    }
+}


### PR DESCRIPTION
## 功能描述

本PR增强了UnLua对GameFeature插件和普通插件的支持，使得插件中的蓝图可以更方便地绑定Lua脚本。

主要改进包括：

1. 扩展了Lua脚本搜索路径，添加了对所有插件类型的支持
2. 实现了插件Lua脚本的特殊查找逻辑，能够自动定位到正确的目录
3. 优化了对点分隔符模块名称的处理，能够更好地映射到文件系统路径
4. 添加了详细的调试日志输出，便于排查脚本加载问题

## 应用场景

- 在GameFeature插件中使用Lua脚本
- 简化多插件项目中的Lua模块组织
- 支持常见的插件命名和目录结构约定

## 使用方法

蓝图只需实现UnLuaInterface接口并返回"PluginName.ModuleName"格式的模块名，
UnLua就能自动在以下位置查找对应的Lua脚本文件：

- `Plugins/GameFeatures/PluginName/Content/Script/PluginName/ModuleName.lua`
- `Plugins/PluginName/Content/Script/PluginName/ModuleName.lua`
- `Plugins/GameFeatures/PluginName/Content/Script/ModuleName.lua`
- `Plugins/PluginName/Content/Script/ModuleName.lua`