### PR TITLE
修复TSoftObjectPtr作为结构体第一个成员变量时metatable异常的问题

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Private/ReflectionUtils/PropertyDesc.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/ReflectionUtils/PropertyDesc.cpp
@@ -416,7 +416,7 @@ class FSoftObjectPropertyDesc : public FPropertyDesc
 {
 public:
     explicit FSoftObjectPropertyDesc(FProperty* InProperty)
-        : FPropertyDesc(InProperty)
+        : FPropertyDesc(InProperty), bFirstPropOfScriptStruct(GetPropertyOuter(Property)->IsA<UScriptStruct>() && Property->GetOffset_ForInternal() == 0)
     {
     }
 
@@ -463,7 +463,7 @@ public:
             }
             else
             {
-                UnLua::PushPointer(L, (void*)ValuePtr, "FSoftObjectPtr", false);
+                UnLua::PushPointer(L, (void*)ValuePtr, "FSoftObjectPtr", bFirstPropOfScriptStruct);
             }
         }
     }
@@ -525,6 +525,9 @@ public:
         return true;
     };
 #endif
+
+protected:
+	bool bFirstPropOfScriptStruct;
 };
 
 /**


### PR DESCRIPTION
Issues #723 提及:TSoftObjectPtr作为结构体第一个成员变量时metatable异常
复现流程:
1. 创建结构体, 将TSoftObjectPtr作为结构体第一个成员变量
2. 访问self.MyStruct.MySoftPtr
3. 访问self.MyStruct
4. 再次访问self.MyStruct.MySoftPtr, 此时获取到的为结构体自身而不是软指针

查看历史记录为Unlua2.0版本中FSoftObjectPropertyDesc基类更改导致PushPointer时bAlwaysCreate变量维护不正确导致,应当在作为结构体第一个成员变量为true.