### PR TITLE
修正：增加Class校验

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Private/ReflectionUtils/PropertyDesc.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/ReflectionUtils/PropertyDesc.cpp
@@ -271,7 +271,7 @@ public:
     explicit FObjectPropertyDesc(FProperty *InProperty, bool bSoftObject)
         : FPropertyDesc(InProperty), MetaClass(nullptr), IsSoftObject(bSoftObject)
     {
-        if (ObjectBaseProperty->PropertyClass->IsChildOf(UClass::StaticClass()))
+        if (ObjectBaseProperty->PropertyClass && ObjectBaseProperty->PropertyClass->IsChildOf(UClass::StaticClass()))
         {
             MetaClass = bSoftObject ? (((FSoftClassProperty*)Property)->MetaClass) : ((FClassProperty*)Property)->MetaClass;
         }


### PR DESCRIPTION
修正某些情况下因为Class为空而导致的崩溃。

复现步骤：
在DS的Lua脚本中存储了一个Widget的指针（通过蓝图里创建变量），在DS打包到Linux之后，读取变量时崩溃。

```
Fatal error!

0x0000000007ac0658 StarsServer-ASan-Linux-Shipping!UStruct::IsChildOf(UStruct const*) const [C:/unrealengine-4.27/Engine/Source/Runtime/CoreUObject/Public/UObject/Class.h:485]
0x0000000007c27c0a StarsServer-ASan-Linux-Shipping!FObjectPropertyDesc::FObjectPropertyDesc(FProperty*, bool) [C:/StarsProject/asan_source/Plugins/UnLua/Source/UnLua/Private/ReflectionUtils/PropertyDesc.cpp:274]
0x0000000007c20492 StarsServer-ASan-Linux-Shipping!FPropertyDesc::Create(FProperty*) [C:/StarsProject/asan_source/Plugins/UnLua/Source/UnLua/Private/ReflectionUtils/PropertyDesc.cpp:1577]
0x0000000007c1f134 StarsServer-ASan-Linux-Shipping!FClassDesc::RegisterField(FName, FClassDesc*) [C:/StarsProject/asan_source/Plugins/UnLua/Source/UnLua/Private/ReflectionUtils/ClassDesc.cpp:137]
0x0000000007c1ef31 StarsServer-ASan-Linux-Shipping!FClassDesc::RegisterField(FName, FClassDesc*) [C:/StarsProject/asan_source/Plugins/UnLua/Source/UnLua/Private/ReflectionUtils/ClassDesc.cpp:127]
0x0000000007ca9b4b StarsServer-ASan-Linux-Shipping!GetFieldInternal(lua_State*) [C:/StarsProject/asan_source/Plugins/UnLua/Source/UnLua/Private/LuaCore.cpp:961]
0x0000000007bf759e StarsServer-ASan-Linux-Shipping!Class_Index(lua_State*) [C:/StarsProject/asan_source/Plugins/UnLua/Source/UnLua/Private/LuaCore.cpp:1393]
0x0000000015ddb797 StarsServer-ASan-Linux-Shipping!luaD_precall()
0x0000000015ddbade StarsServer-ASan-Linux-Shipping!ccall()
0x0000000015ddba58 StarsServer-ASan-Linux-Shipping!luaD_call()
0x0000000015e02fe4 StarsServer-ASan-Linux-Shipping!luaT_callTMres()
0x0000000015e058e3 StarsServer-ASan-Linux-Shipping!luaV_finishget()
0x0000000015e08121 StarsServer-ASan-Linux-Shipping!luaV_execute()
0x0000000015ddbb03 StarsServer-ASan-Linux-Shipping!ccall()
0x0000000015ddba58 StarsServer-ASan-Linux-Shipping!luaD_call()
0x0000000015e02fe4 StarsServer-ASan-Linux-Shipping!luaT_callTMres()
0x0000000015e058e3 StarsServer-ASan-Linux-Shipping!luaV_finishget()
0x0000000015e0855b StarsServer-ASan-Linux-Shipping!luaV_execute()
0x0000000015ddbb03 StarsServer-ASan-Linux-Shipping!ccall()
0x0000000015ddbb48 StarsServer-ASan-Linux-Shipping!luaD_callnoyield()
0x0000000015dd3aef StarsServer-ASan-Linux-Shipping!f_call()
0x0000000015dda54f StarsServer-ASan-Linux-Shipping!luaD_rawrunprotected()
0x0000000015ddc233 StarsServer-ASan-Linux-Shipping!luaD_pcall()
0x0000000015dd39b6 StarsServer-ASan-Linux-Shipping!lua_pcallk(+0xd5)
0x0000000007c22914 StarsServer-ASan-Linux-Shipping!FFunctionDesc::CallLuaInternal(lua_State*, void*, FOutParmRec*, void*) const [C:/StarsProject/asan_source/Plugins/UnLua/Source/UnLua/Private/ReflectionUtils/FunctionDesc.cpp:620]
0x0000000007c222b2 StarsServer-ASan-Linux-Shipping!FFunctionDesc::CallLua(lua_State*, long long, long long, FFrame&, void*) [C:/StarsProject/asan_source/Plugins/UnLua/Source/UnLua/Private/ReflectionUtils/FunctionDesc.cpp:232]
0x0000000007c0c8a9 StarsServer-ASan-Linux-Shipping!UnLua::FFunctionRegistry::Invoke(ULuaFunction*, UObject*, FFrame&, void*) [C:/StarsProject/asan_source/Plugins/UnLua/Source/UnLua/Private/Registries/FunctionRegistry.cpp:83]
0x0000000007c0c301 StarsServer-ASan-Linux-Shipping!ULuaFunction::execCallLua(UObject*, FFrame&, void*) [C:/StarsProject/asan_source/Plugins/UnLua/Source/UnLua/Private/LuaFunction.cpp:53]
0x000000000f5aa57d StarsServer-ASan-Linux-Shipping!UFunction::Invoke(UObject*, FFrame&, void*) [C:/unrealengine-4.27/Engine/Source/Runtime/CoreUObject/Private/UObject/Class.cpp:5679]
```