### PR TITLE
修复：废弃UObject_Delete接口 这可能导致lua gc时崩溃

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Private/BaseLib/LuaLib_Object.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/BaseLib/LuaLib_Object.cpp
@@ -231,33 +231,6 @@ int32 UObject_Identical(lua_State* L)
  */
 int32 UObject_Delete(lua_State* L)
 {
-    const auto NumParams = lua_gettop(L);
-    if (NumParams != 1)
-        return luaL_error(L, "invalid parameters");
-
-    bool bTwoLvlPtr = false;
-    bool bClassMetatable = false;
-    void* Userdata = GetUserdata(L, 1, &bTwoLvlPtr, &bClassMetatable);
-    if (!Userdata)
-        return 0;
-
-    if (bClassMetatable)
-        return 0;
-
-    if (!bTwoLvlPtr)
-        return 0;
-
-    UObject* Object = (UObject*)*(void**)Userdata;
-    if (UnLua::LowLevel::IsReleasedPtr(Object))
-        return 0;
-
-    const bool bValid = UnLua::IsUObjectValid(Object) && IsValid(Object) && !Object->IsUnreachable();
-    if (!bValid)
-    {
-        return 0;
-    }
-
-    UnLua::FLuaEnv::FindEnvChecked(L).GetObjectRegistry()->NotifyUObjectLuaGC(Object);
     return 0;
 }
 
@@ -276,7 +249,7 @@ static const luaL_Reg UObjectLib[] =
     {"Release", UObject_Release},
     {"Destroy", UObject_Release},
     {"__eq", UObject_Identical},
-    {"__gc", UObject_Delete},
+    // {"__gc", UObject_Delete},
     {nullptr, nullptr}
 };
 

--- a/Plugins/UnLua/Source/UnLua/Private/Registries/ClassRegistry.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/Registries/ClassRegistry.cpp
@@ -203,9 +203,9 @@ namespace UnLua
                 lua_pushcfunction(L, UObject_Identical);
                 lua_rawset(L, -3);
 
-                lua_pushstring(L, "__gc");
-                lua_pushcfunction(L, UObject_Delete);
-                lua_rawset(L, -3);
+                // lua_pushstring(L, "__gc");
+                // lua_pushcfunction(L, UObject_Delete);
+                // lua_rawset(L, -3);
             }
         }
 


### PR DESCRIPTION
UObject_Delete已无实际用途，废弃该回调。这个接口只有ULuaDelegateHandler用到，而ULuaDelegateHandler已经在PostGC时自动移除引用，不需要这里单独触发。