### PR TITLE
修正：GC时没有清理关联Delegate已经失效的Handle

### DIFF
--- a/Plugins/UnLua/Source/UnLua/Private/Registries/DelegateRegistry.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/Registries/DelegateRegistry.cpp
@@ -41,29 +41,43 @@ namespace UnLua
 
     void FDelegateRegistry::OnPostGarbageCollect()
     {
+        TSet<void*> InvalidDelegates;
         TArray<TTuple<void*, FDelegateInfo>> InvalidPairs;
         for (auto& Pair : Delegates)
         {
             if (!Pair.Value.Owner.IsValid())
+            {
                 InvalidPairs.Add(Pair);
+                InvalidDelegates.Add(Pair.Key);
+            }
         }
 
         for (int i = 0; i < InvalidPairs.Num(); i++)
         {
             const auto& Pair = InvalidPairs[i];
+
             if (Pair.Value.bIsMulticast)
+            {
                 Clear(Pair.Key);
+            }
             else
+            {
                 Unbind(Pair.Key);
+            }
             Delegates.Remove(Pair.Key);
+
             if (Pair.Value.bDeleteOnRemove)
+            {
                 delete (FScriptDelegate*)Pair.Key;
+            }
         }
 
         TArray<FLuaDelegatePair> ToRemove;
         for (auto& Pair : CachedHandlers)
         {
-            if (Pair.Key.SelfObject.IsStale())
+            if (Pair.Key.SelfObject.IsStale()
+                || !Pair.Value.IsValid()
+                || InvalidDelegates.Contains(Pair.Value->Delegate))
             {
                 ToRemove.Add(Pair.Key);
                 Env->AutoObjectReference.Remove(Pair.Value.Get());


### PR DESCRIPTION
当GC时，如果Delegate已经销毁了，原逻辑没有清理缓存了该地址的ULuaDelegateHandler。
从而导致如果地址出现了复用，其他Delegate使用了相同的地址，那么就会有可能校验时报错。

https://github.com/Tencent/UnLua/issues/766