### PR TITLE
fix: UE 5.7 compatibility (phase 1 - deprecated API replacement)

### DIFF
--- a/Plugins/UnLua/Source/ThirdParty/Lua/Lua.Build.cs
+++ b/Plugins/UnLua/Source/ThirdParty/Lua/Lua.Build.cs
@@ -31,8 +31,13 @@ public class Lua : ModuleRules
     public Lua(ReadOnlyTargetRules Target) : base(Target)
     {
         Type = ModuleType.External;
+#if UE_5_5_OR_LATER
+        CppCompileWarningSettings.UndefinedIdentifierWarningLevel = WarningLevel.Off;
+        CppCompileWarningSettings.ShadowVariableWarningLevel = WarningLevel.Off;
+#else
         bEnableUndefinedIdentifierWarnings = false;
         ShadowVariableWarningLevel = WarningLevel.Off;
+#endif
 
         m_LuaVersion = GetLuaVersion();
         m_Config = GetConfigName();
@@ -442,12 +447,12 @@ public class Lua : ModuleRules
                 return "Ninja";
             if (Target.Platform.IsInGroup(UnrealPlatformGroup.Windows))
             {
+#if !UE_5_7_OR_LATER
                 if (Target.WindowsPlatform.Compiler == WindowsCompiler.VisualStudio2019)
                     return "Visual Studio 16 2019";
-#if UE_4_27_OR_LATER
+#endif
                 if (Target.WindowsPlatform.Compiler == WindowsCompiler.VisualStudio2022)
                     return "Visual Studio 17 2022";
-#endif
             }
         }
 

--- a/Plugins/UnLua/Source/UnLua/Public/UnLuaEx.inl
+++ b/Plugins/UnLua/Source/UnLua/Public/UnLuaEx.inl
@@ -94,7 +94,7 @@ namespace UnLua
     {
         static void Generate(FString &Buffer, int32 Index)
         {
-            FString TypeName = TTypeIntelliSense<typename TChooseClass<TIsPointer<T1>::Value, typename TDecay<typename TRemovePointer<T1>::Type>::Type*, typename TDecay<T1>::Type>::Result>::GetName();
+            FString TypeName = TTypeIntelliSense<std::conditional_t<TIsPointer<T1>::Value, typename TDecay<typename TRemovePointer<T1>::Type>::Type*, typename TDecay<T1>::Type>>::GetName();
             Buffer += FString::Printf(TEXT("---@param P%d %s %s\r\n"), Index, *TypeName, *TArgumentComment<T1>::Get());
             TArgumentIntelliSense<T2...>::Generate(Buffer, Index + 1);
         }
@@ -123,7 +123,7 @@ namespace UnLua
         }
 
         // return 
-        FString ReturnTypeName = TTypeIntelliSense<typename TChooseClass<TIsPointer<RetType>::Value, typename TDecay<typename TRemovePointer<RetType>::Type>::Type*, typename TDecay<RetType>::Type>::Result>::GetName();
+        FString ReturnTypeName = TTypeIntelliSense<std::conditional_t<TIsPointer<RetType>::Value, typename TDecay<typename TRemovePointer<RetType>::Type>::Type*, typename TDecay<RetType>::Type>>::GetName();
         if (ReturnTypeName.Len() > 0)
         {
             Buffer += FString::Printf(TEXT("---@return %s\r\n"), *ReturnTypeName);
@@ -880,7 +880,7 @@ namespace UnLua
     template <bool bIsReflected>
     void TExportedClassBase<bIsReflected>::GenerateIntelliSense(FString &Buffer) const
     {
-        GenerateIntelliSenseInternal(Buffer, typename TChooseClass<bIsReflected, FTrue, FFalse>::Result());
+        GenerateIntelliSenseInternal(Buffer, std::conditional_t<bIsReflected, FTrue, FFalse>());
     }
 
     template <bool bIsReflected>
@@ -951,7 +951,7 @@ namespace UnLua
     TExportedClass<bIsReflected, ClassType, CtorArgType...>::TExportedClass(const char *InName, const char *InSuperClassName)
         : FExportedClassBase(InName, InSuperClassName)
     {
-        AddDefaultFunctions(typename TChooseClass<bIsReflected, FTrue, FFalse>::Result());
+        AddDefaultFunctions(std::conditional_t<bIsReflected, FTrue, FFalse>());
     }
 
     template <bool bIsReflected, typename ClassType, typename... CtorArgType>
@@ -1029,14 +1029,14 @@ namespace UnLua
     template <bool bIsReflected, typename ClassType, typename... CtorArgType>
     void TExportedClass<bIsReflected, ClassType, CtorArgType...>::AddDefaultFunctions(FFalse NotReflected)
     {
-        AddConstructor(typename TChooseClass<TIsConstructible<ClassType, CtorArgType...>::Value, FTrue, FFalse>::Result());
-        AddDestructor(typename TChooseClass<TAnd<TIsDestructible<ClassType>, TNot<TIsTriviallyDestructible<ClassType>>>::Value, FFalse, FTrue>::Result());
+        AddConstructor(std::conditional_t<TIsConstructible<ClassType, CtorArgType...>::Value, FTrue, FFalse>());
+        AddDestructor(std::conditional_t<TIsDestructible<ClassType>::Value && !std::is_trivially_destructible_v<ClassType>, FFalse, FTrue>());
     }
 
     template <bool bIsReflected, typename ClassType, typename... CtorArgType>
     void TExportedClass<bIsReflected, ClassType, CtorArgType...>::AddDefaultFunctions(FTrue Reflected)
     {
-        AddDefaultFunctions_Reflected(typename TChooseClass<TPointerIsConvertibleFromTo<ClassType, UObject>::Value, FTrue, FFalse>::Result());
+        AddDefaultFunctions_Reflected(std::conditional_t<TPointerIsConvertibleFromTo<ClassType, UObject>::Value, FTrue, FFalse>());
     }
 
     template <bool bIsReflected, typename ClassType, typename... CtorArgType>
@@ -1045,7 +1045,7 @@ namespace UnLua
         int32 NumArgs = sizeof...(CtorArgType);
         if (NumArgs > 0)
         {
-            AddConstructor(typename TChooseClass<TIsConstructible<ClassType, CtorArgType...>::Value, FTrue, FFalse>::Result());
+            AddConstructor(std::conditional_t<TIsConstructible<ClassType, CtorArgType...>::Value, FTrue, FFalse>());
         }
     }
 

--- a/Plugins/UnLua/Source/UnLua/Public/UnLuaLegacy.h
+++ b/Plugins/UnLua/Source/UnLua/Public/UnLuaLegacy.h
@@ -19,6 +19,7 @@
 #include "UnLuaTemplate.h"
 #include "LuaValue.h"
 #include "LuaEnv.h"
+#include <type_traits>
 
 namespace UnLua
 {
@@ -831,7 +832,7 @@ namespace UnLua
         virtual bool IsTriviallyDestructible() const override
         {
             static_assert(TIsDestructible<T>::Value, "type must be destructible!");
-            return TIsTriviallyDestructible<T>::Value;
+            return std::is_trivially_destructible_v<T>;
         }
 
         virtual int32 GetSize() const override { return sizeof(T); }
@@ -853,18 +854,18 @@ namespace UnLua
         virtual void Destruct(void* Dest) const override
         {
             static_assert(TIsDestructible<T>::Value, "type must be destructible!");
-            DestructInternal((T*)Dest, typename TChooseClass<TIsTriviallyDestructible<T>::Value, FTrue, FFalse>::Result());
+            DestructInternal((T*)Dest, std::conditional_t<std::is_trivially_destructible_v<T>, FTrue, FFalse>());
         }
 
         virtual void Copy(void* Dest, const void* Src) const override
         {
             static_assert(TIsCopyConstructible<T>::Value, "type must be copy constructible!");
-            CopyInternal((T*)Dest, (const T*)Src, typename TChooseClass<TIsTriviallyCopyConstructible<T>::Value, FTrue, FFalse>::Result());
+            CopyInternal((T*)Dest, (const T*)Src, std::conditional_t<TIsTriviallyCopyConstructible<T>::Value, FTrue, FFalse>());
         }
 
         virtual bool Identical(const void* A, const void* B) const override
         {
-            return IdenticalInternal((const T*)A, (const T*)B, typename TChooseClass<THasEqualityOperator<T>::Value, FTrue, FFalse>::Result());
+            return IdenticalInternal((const T*)A, (const T*)B, std::conditional_t<THasEqualityOperator<T>::Value, FTrue, FFalse>());
         }
 
         virtual FString GetName() const override { return FString(TType<typename TDecay<T>::Type>::GetName()); }
@@ -890,7 +891,7 @@ namespace UnLua
         {
             static_assert(TIsCopyConstructible<T>::Value, "type must be copy constructible!");
             T V = UnLua::Get(L, IndexInStack, TType<T>());
-            CopyInternal((T*)ValuePtr, &V, typename TChooseClass<TIsTriviallyCopyConstructible<T>::Value, FTrue, FFalse>::Result());
+            CopyInternal((T*)ValuePtr, &V, std::conditional_t<TIsTriviallyCopyConstructible<T>::Value, FTrue, FFalse>());
             return false;
         }
 

--- a/Plugins/UnLua/Source/UnLua/Public/UnLuaSettings.h
+++ b/Plugins/UnLua/Source/UnLua/Public/UnLuaSettings.h
@@ -52,6 +52,6 @@ public:
     TSubclassOf<ULuaModuleLocator> ModuleLocatorClass = ULuaModuleLocator::StaticClass();
 
     /** List of classes to bind on startup. */
-    UPROPERTY(config, EditAnywhere, Category=Runtime, meta = (MetaClass="Object", AllowAbstract="True", DisplayName = "List of classes to bind on startup"))
+    UPROPERTY(config, EditAnywhere, Category=Runtime, meta = (MetaClass="/Script/CoreUObject.Object", AllowAbstract="True", DisplayName = "List of classes to bind on startup"))
     TArray<FSoftClassPath> PreBindClasses;
 };

--- a/Plugins/UnLua/Source/UnLua/Public/UnLuaTemplate.h
+++ b/Plugins/UnLua/Source/UnLua/Public/UnLuaTemplate.h
@@ -91,7 +91,7 @@ namespace UnLua
     template <typename T> struct TArgTypeTraits
     {
         typedef typename TDecay<T>::Type RT;
-        typedef typename TChooseClass<TIsPrimitiveTypeOrPointer<RT>::Value, RT, typename std::remove_cv<T>::type>::Result Type;
+        typedef std::conditional_t<TIsPrimitiveTypeOrPointer<RT>::Value, RT, typename std::remove_cv<T>::type> Type;
     };
     
     

--- a/Plugins/UnLuaExtensions/LuaProtobuf/Source/LuaProtobuf.Build.cs
+++ b/Plugins/UnLuaExtensions/LuaProtobuf/Source/LuaProtobuf.Build.cs
@@ -27,7 +27,11 @@ public class LuaProtobuf : ModuleRules
 #endif
         bUseUnity = false;
         PCHUsage = PCHUsageMode.NoSharedPCHs;
+#if UE_5_5_OR_LATER
+        CppCompileWarningSettings.UndefinedIdentifierWarningLevel = WarningLevel.Off;
+#else
         bEnableUndefinedIdentifierWarnings = false;
+#endif
 
         PublicDependencyModuleNames.AddRange(
             new[]

--- a/Plugins/UnLuaExtensions/LuaRapidjson/Source/LuaRapidjson.Build.cs
+++ b/Plugins/UnLuaExtensions/LuaRapidjson/Source/LuaRapidjson.Build.cs
@@ -27,7 +27,11 @@ public class LuaRapidjson : ModuleRules
 #endif
         bUseUnity = false;
         PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
+#if UE_5_5_OR_LATER
+        CppCompileWarningSettings.UndefinedIdentifierWarningLevel = WarningLevel.Off;
+#else
         bEnableUndefinedIdentifierWarnings = false;
+#endif
         bEnableExceptions = true;
 
         PublicDependencyModuleNames.AddRange(

--- a/Plugins/UnLuaExtensions/LuaSocket/Source/LuaSocket.Build.cs
+++ b/Plugins/UnLuaExtensions/LuaSocket/Source/LuaSocket.Build.cs
@@ -27,7 +27,11 @@ public class LuaSocket : ModuleRules
 #endif
         bUseUnity = false;
         PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
+#if UE_5_5_OR_LATER
+        CppCompileWarningSettings.UndefinedIdentifierWarningLevel = WarningLevel.Off;
+#else
         bEnableUndefinedIdentifierWarnings = false;
+#endif
 
         PublicDependencyModuleNames.AddRange(
             new[]


### PR DESCRIPTION
- Replace TChooseClass with std::conditional_t (UnLuaLegacy.h, UnLuaTemplate.h, UnLuaEx.inl)
- Replace TIsTriviallyDestructible with std::is_trivially_destructible_v
- Replace bEnableUndefinedIdentifierWarnings with CppCompileWarningSettings (5.5+)
- Remove VisualStudio2019 reference on 5.7+ (kept via #if for older versions)
- Fix MetaClass to full object path format

All changes are backward-compatible with UE 5.4+.