### PR TITLE
Add UE 5.7 support and repair the test suite

### DIFF
--- a/Content/Script/Tests/Regression/IssueOverrides/IssueOverridesObject.lua
+++ b/Content/Script/Tests/Regression/IssueOverrides/IssueOverridesObject.lua
@@ -1,0 +1,7 @@
+local M = UnLua.Class()
+
+function M:CollectInfo()
+    return self.Overridden.CollectInfo(self) + 1
+end
+
+return M

--- a/Plugins/UnLua/Source/UnLua/Private/LuaOverridesClass.cpp
+++ b/Plugins/UnLua/Source/UnLua/Private/LuaOverridesClass.cpp
@@ -71,7 +71,9 @@ void ULuaOverridesClass::AddToOwner()
     if (!Class)
         return;
 
-#if UE_VERSION_NEWER_THAN(5, 2, 1)
+#if UE_VERSION_NEWER_THAN(5, 2, 1) && UE_VERSION_OLDER_THAN(5, 7, 0)
+    // 5.3~5.6: Children is TObjectPtr but UField::Next is still a raw pointer,
+    // so the chain cannot be walked in place with a single slot type
     auto ChildrenPtr = Class->Children.Get();
 
     auto Field = &ChildrenPtr;
@@ -101,7 +103,9 @@ void ULuaOverridesClass::RemoveFromOwner()
     if (!Class)
         return;
 
-#if UE_VERSION_NEWER_THAN(5, 2, 1)
+#if UE_VERSION_NEWER_THAN(5, 2, 1) && UE_VERSION_OLDER_THAN(5, 7, 0)
+    // 5.3~5.6: Children is TObjectPtr but UField::Next is still a raw pointer,
+    // so the chain cannot be walked in place with a single slot type
     auto ChildrenPtr = Class->Children.Get();
 
     auto Field = &ChildrenPtr;

--- a/Plugins/UnLuaTestSuite/Source/UnLuaTestSuite/Private/Specs/LuaDeadLoopCheck.spec.cpp
+++ b/Plugins/UnLuaTestSuite/Source/UnLuaTestSuite/Private/Specs/LuaDeadLoopCheck.spec.cpp
@@ -41,6 +41,11 @@ void FLuaDeadLoopCheckSpec::Define()
 
         It(TEXT("设置防止无限循环的超时时间"), EAsyncExecution::TaskGraphMainThread, [this]()
         {
+            // a preceding PIE-based test deactivates UnLua on a deferred tick, so the module
+            // may still be active here; Startup() would then early-return without applying
+            // DeadLoopCheck to FDeadLoopCheck::Timeout and the chunk below never times out
+            UnLua::Shutdown();
+
             auto& Settings = *GetMutableDefault<UUnLuaSettings>();
             Settings.DeadLoopCheck = 1;
 

--- a/Plugins/UnLuaTestSuite/Source/UnLuaTestSuite/Private/Specs/LuaLib_Class.spec.cpp
+++ b/Plugins/UnLuaTestSuite/Source/UnLuaTestSuite/Private/Specs/LuaLib_Class.spec.cpp
@@ -59,12 +59,17 @@ void FUnLuaLibClassSpec::Define()
     {
         It(TEXT("正确获取类默认对象"), EAsyncExecution::TaskGraphMainThread, [this]()
         {
-            const UObject* Expected = LoadClass<AGameModeBase>(nullptr, TEXT("/Game/Core/Blueprints/BP_Game.BP_Game_C"))->GetDefaultObject();
+            const auto Class = LoadClass<AGameModeBase>(nullptr, TEXT("/Game/Core/Blueprints/BP_Game.BP_Game_C"));
+            if (!TestNotNull(TEXT("BP_Game class"), Class))
+                return;
+            const UObject* Expected = Class->GetDefaultObject();
             const char* Chunk = "\
             local GameModeClass = UE.UClass.Load('/Game/Core/Blueprints/BP_Game.BP_Game_C')\
             return GameModeClass:GetDefaultObject()";
             UnLua::RunChunk(L, Chunk);
-            const UObject* Actual = static_cast<UObject*>(UnLua::GetPointer(L, -1));
+            // UObject userdata is managed by FObjectRegistry, so it must be read back
+            // with GetUObject; GetPointer only understands raw/smart-pointer userdata
+            const UObject* Actual = UnLua::GetUObject(L, -1);
             TEST_EQUAL(Actual, Expected);
         });
     });

--- a/Source/TPSProject.Target.cs
+++ b/Source/TPSProject.Target.cs
@@ -20,7 +20,10 @@ public class TPSProjectTarget : TargetRules
     public TPSProjectTarget(TargetInfo Target) : base(Target)
     {
         Type = TargetType.Game;
-#if UE_5_4_OR_LATER
+#if UE_5_7_OR_LATER
+        DefaultBuildSettings = BuildSettingsVersion.V6;
+        IncludeOrderVersion = EngineIncludeOrderVersion.Latest;
+#elif UE_5_4_OR_LATER
         DefaultBuildSettings = BuildSettingsVersion.V4;
         IncludeOrderVersion = EngineIncludeOrderVersion.Latest;
 #else

--- a/Source/TPSProjectEditor.Target.cs
+++ b/Source/TPSProjectEditor.Target.cs
@@ -20,7 +20,10 @@ public class TPSProjectEditorTarget : TargetRules
     public TPSProjectEditorTarget(TargetInfo Target) : base(Target)
     {
         Type = TargetType.Editor;
-#if UE_5_4_OR_LATER
+#if UE_5_7_OR_LATER
+        DefaultBuildSettings = BuildSettingsVersion.V6;
+        IncludeOrderVersion = EngineIncludeOrderVersion.Latest;
+#elif UE_5_4_OR_LATER
         DefaultBuildSettings = BuildSettingsVersion.V4;
         IncludeOrderVersion = EngineIncludeOrderVersion.Latest;
 #else

--- a/Source/TPSProjectServer.Target.cs
+++ b/Source/TPSProjectServer.Target.cs
@@ -19,7 +19,10 @@ public class TPSProjectServerTarget : TargetRules
     public TPSProjectServerTarget(TargetInfo Target) : base(Target)
     {
         Type = TargetType.Server;
-#if UE_5_4_OR_LATER
+#if UE_5_7_OR_LATER
+        DefaultBuildSettings = BuildSettingsVersion.V6;
+        IncludeOrderVersion = EngineIncludeOrderVersion.Latest;
+#elif UE_5_4_OR_LATER
         DefaultBuildSettings = BuildSettingsVersion.V4;
         IncludeOrderVersion = EngineIncludeOrderVersion.Latest;
 #else

--- a/TPSProject.uproject
+++ b/TPSProject.uproject
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"EngineAssociation": "5.6",
+	"EngineAssociation": "5.7",
 	"Category": "",
 	"Description": "",
 	"Modules": [


### PR DESCRIPTION
Adds UE 5.7 support. Two changes are needed for 5.7 itself; the other three
commits fix test suite problems I hit while verifying on a clean checkout.

**5.7 support**
- `UField::Next` is `TObjectPtr<UField>` in 5.7, so the `UField**` chain walk
  in `ULuaOverridesClass` no longer compiles (fixes #763). The `Children.Get()`
  copy workaround is now limited to 5.3~5.6; other versions walk the chain
  in place.
- TPSProject targets use `BuildSettingsVersion.V6` on 5.7+. Installed 5.7
  builds reject the V4 profile before compiling
  (`UndefinedIdentifierWarningLevel: Off != Error`).

**Test suite fixes** (not 5.7-specific)
- `IssueOverridesObject.lua` was never committed, so the IssueOverrides test
  always failed on a clean checkout. Reconstructed it from what the C++ test
  expects.
- The DeadLoopCheck spec deadlocks when it runs right after a PIE-based test:
  UnLua is deactivated on a deferred tick, so `Startup()` early-returns and
  the timeout never gets applied — this is what froze the editor on full
  suite runs. The spec now calls `Shutdown()` first.
- The GetDefaultObject spec read the result with `UnLua::GetPointer`, which
  returns null for UObject userdata, so it failed even though Lua returned
  the correct CDO. Changed to `GetUObject` (same as the Load spec) and added
  a null check on `LoadClass` so a missing asset doesn't crash the run.

**Tests**: full UnLua suite on UE 5.7.4, Win64.
In-editor: 327/327. Headless (`-nullrhi`): 326/327 — Issue434 fails only
under nullrhi (it uses UMG), passes in-editor.

Note: loading `BP_AIController` logs a `PawnActionsComponent` warning (class
removed from the engine). Left as-is — fixing it requires resaving assets in
5.7, which breaks older engine versions.